### PR TITLE
 Added aWarpSharp for GCC

### DIFF
--- a/src/aWarp.h
+++ b/src/aWarp.h
@@ -41,7 +41,7 @@ void MERGE(Warp, SMAGL)(PVideoFrame &src, PVideoFrame &edg, PVideoFrame &dst, in
 	const int edg_pitch = edg->GetPitch(plane_edg);
 	const int dst_pitch = dst->GetPitch(plane);
 	const int row_size = dst->GetRowSize() >> dst_vi.GetPlaneWidthSubsampling (plane);
-	const int i = -(row_size + 3 & ~3);
+	const int i = -((row_size + 3) & ~3);
 	const int c = row_size + i - 1;
 	const int height = dst->GetHeight() >> dst_vi.GetPlaneHeightSubsampling (plane);
 	const unsigned char *psrc = src->GetReadPtr(plane) - i*SMAG;
@@ -65,7 +65,7 @@ void MERGE(Warp, SMAGL)(PVideoFrame &src, PVideoFrame &edg, PVideoFrame &dst, in
       int edg_pitchp = -(y ? edg_pitch : 0);
       int edg_pitchn = y != height - 1 ? edg_pitch : 0;
 
-      __asm {
+      /*__asm {
         mov	QSI, psrc
         mov	QCX, pedg
         mov	QAX, pdst
@@ -458,7 +458,7 @@ void MERGE(Warp, SMAGL)(PVideoFrame &src, PVideoFrame &edg, PVideoFrame &dst, in
           pop	QCX
 #endif
           pop	QBP
-      }
+      }*/
       psrc += src_pitch*SMAG;
       pedg += edg_pitch;
       pdst += dst_pitch;

--- a/src/aWarp.h
+++ b/src/aWarp.h
@@ -196,30 +196,30 @@ void MERGE(Warp, SMAGL)(PVideoFrame &src, PVideoFrame &edg, PVideoFrame &dst, in
       asm volatile ( \
         "movd       %%xmm2, %%eax           \n\t" \
         "psrldq     $4, %%xmm2              \n\t" \
-        "pinsrw     $1, 0x01(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $1, 0x01(%%rax,%%rdx), %%xmm1 \n\t" \
+        "pinsrw     $1, 4(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $1, 4(%%rax,%%rdx), %%xmm1 \n\t" \
         "movd       %%xmm2, %%eax           \n\t" \
         "psrldq     $4, %%xmm2              \n\t" \
-        "pinsrw     $2, 0x02(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $2, 0x02(%%rax,%%rdx), %%xmm1 \n\t" \
+        "pinsrw     $2, 8(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $2, 8(%%rax,%%rdx), %%xmm1 \n\t" \
         "movd       %%xmm2, %%eax           \n\t" \
-        "pinsrw     $3, 0x03(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $3, 0x03(%%rax,%%rdx), %%xmm1 \n\t" \
+        "pinsrw     $3, 12(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $3, 12(%%rax,%%rdx), %%xmm1 \n\t" \
         "movd       %%xmm7, %%eax           \n\t" \
         "psrldq     $4, %%xmm7              \n\t" \
-        "pinsrw     $4, 0x04(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $4, 0x04(%%rax,%%rdx), %%xmm1 \n\t" \
+        "pinsrw     $4, 16(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $4, 16(%%rax,%%rdx), %%xmm1 \n\t" \
         "movd       %%xmm7, %%eax           \n\t" \
         "psrldq     $4, %%xmm7              \n\t" \
-        "pinsrw     $5, 0x05(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $5, 0x05(%%rax,%%rdx), %%xmm1 \n\t" \
+        "pinsrw     $5, 20(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $5, 20(%%rax,%%rdx), %%xmm1 \n\t" \
         "movd       %%xmm7, %%eax           \n\t" \
         "psrldq     $4, %%xmm7              \n\t" \
-        "pinsrw     $6, 0x06(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $6, 0x06(%%rax,%%rdx), %%xmm1 \n\t" \
+        "pinsrw     $6, 24(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $6, 24(%%rax,%%rdx), %%xmm1 \n\t" \
         "movd       %%xmm7, %%eax           \n\t" \
-        "pinsrw     $7, 0x07(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $7, 0x07(%%rax,%%rdx), %%xmm1 \n\t" \
+        "pinsrw     $7, 28(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $7, 28(%%rax,%%rdx), %%xmm1 \n\t" \
     : \
     : \
     : "memory", "cc", "%eax", "%rax", "%rdx", "%rsi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",
@@ -390,37 +390,37 @@ void MERGE(Warp, SMAGL)(PVideoFrame &src, PVideoFrame &edg, PVideoFrame &dst, in
       asm volatile ( \
         "movd       %%xmm2, %%eax           \n\t" \
         "movsxd     %%eax, %%rax            \n\t" \
-        "pinsrw     $1, 0x01(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $1, 0x01(%%rax,%%rdx), %%xmm4 \n\t" \
+        "pinsrw     $1, 4(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $1, 4(%%rax,%%rdx), %%xmm4 \n\t" \
         "psrldq     $4, %%xmm2              \n\t" \
         "movd       %%xmm2, %%eax           \n\t" \
         "movsxd     %%eax, %%rax            \n\t" \
-        "pinsrw     $2, 0x02(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $2, 0x02(%%rax,%%rdx), %%xmm4 \n\t" \
+        "pinsrw     $2, 8(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $2, 8(%%rax,%%rdx), %%xmm4 \n\t" \
         "psrldq     $4, %%xmm2              \n\t" \
         "movd       %%xmm2, %%eax           \n\t" \
         "movsxd     %%eax, %%rax            \n\t" \
-        "pinsrw     $3, 0x03(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $3, 0x03(%%rax,%%rdx), %%xmm4 \n\t" \
+        "pinsrw     $3, 12(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $3, 12(%%rax,%%rdx), %%xmm4 \n\t" \
         "movd       %%xmm7, %%eax           \n\t" \
         "movsxd     %%eax, %%rax            \n\t" \
-        "pinsrw     $4, 0x04(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $4, 0x04(%%rax,%%rdx), %%xmm4 \n\t" \
+        "pinsrw     $4, 16(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $4, 16(%%rax,%%rdx), %%xmm4 \n\t" \
         "psrldq     $4, %%xmm7              \n\t" \
         "movd       %%xmm7, %%eax           \n\t" \
         "movsxd     %%eax, %%rax            \n\t" \
-        "pinsrw     $5, 0x05(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $5, 0x05(%%rax,%%rdx), %%xmm4 \n\t" \
+        "pinsrw     $5, 20(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $5, 20(%%rax,%%rdx), %%xmm4 \n\t" \
         "psrldq     $4, %%xmm7              \n\t" \
         "movd       %%xmm7, %%eax           \n\t" \
         "movsxd     %%eax, %%rax            \n\t" \
-        "pinsrw     $6, 0x06(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $6, 0x06(%%rax,%%rdx), %%xmm4 \n\t" \
+        "pinsrw     $6, 24(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $6, 24(%%rax,%%rdx), %%xmm4 \n\t" \
         "psrldq     $4, %%xmm7              \n\t" \
         "movd       %%xmm7, %%eax           \n\t" \
         "movsxd     %%eax, %%rax            \n\t" \
-        "pinsrw     $7, 0x07(%%rax,%%rsi), %%xmm3 \n\t" \
-        "pinsrw     $7, 0x07(%%rax,%%rdx), %%xmm4 \n\t" \
+        "pinsrw     $7, 28(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $7, 28(%%rax,%%rdx), %%xmm4 \n\t" \
     : \
     : \
     : "memory", "cc", "%eax", "%rax", "%rdx", "%rsi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",

--- a/src/aWarp.h
+++ b/src/aWarp.h
@@ -55,7 +55,7 @@ void MERGE(Warp, SMAGL)(PVideoFrame &src, PVideoFrame &edg, PVideoFrame &dst, in
 	const short x_limit_max[8] = { (short)(c*SMAG)    , (short)((c-1)*SMAG), (short)((c-2)*SMAG), (short)((c-3)*SMAG), 
                                  (short)((c-4)*SMAG), (short)((c-5)*SMAG), (short)((c-6)*SMAG), (short)((c-7)*SMAG)};
 
-  if (g_cpuid & CPUF_SSE2)
+  if (!(g_cpuid & CPUF_SSE2))
   {
     // SSE2 and SSSE3 versions
     for (int y = 0; y < height; y++)
@@ -65,400 +65,441 @@ void MERGE(Warp, SMAGL)(PVideoFrame &src, PVideoFrame &edg, PVideoFrame &dst, in
       int edg_pitchp = -(y ? edg_pitch : 0);
       int edg_pitchn = y != height - 1 ? edg_pitch : 0;
 
-      /*__asm {
-        mov	QSI, psrc
-        mov	QCX, pedg
-        mov	QAX, pdst
-        movsx_int	QDX, src_pitch
-        movsx_int	QBX, edg_pitchp
-        movsx_int	QDI, i          // signed!
-        sub	QAX, 8
-        add	QDX, QSI
-        add	QBX, QCX
-        movd	xmm1, y_limit_min
-        movd	xmm2, y_limit_max
-        movdqu	xmm3, x_limit_min
-        movdqu	xmm4, x_limit_max
-        movd	xmm6, depth
-        movd	xmm0, src_pitch
-        pcmpeqw	xmm7, xmm7
-        psrlw	xmm7, 0Fh
-        punpcklwd	xmm0, xmm7
-        pshufd	xmm1, xmm1, 0
-        pshufd	xmm2, xmm2, 0
-        pshufd	xmm6, xmm6, 0
-        pshufd	xmm0, xmm0, 0
-        packssdw	xmm1, xmm1
-        packssdw	xmm2, xmm2
-        packssdw	xmm6, xmm6
-        pcmpeqw	xmm5, xmm5
-        psllw	xmm5, 0Fh
-        push	QBP            // save ebp, also for x64!
-#if defined(X86_32)
-        // make room for local variables
-        push	edg_pitchn
-        
-        lea	ebp, [esp - 5Ch]
-        and ebp, ~0Fh
-        xchg	esp, ebp
-        
-        push	eax
-        push	ebp
-        mov	ebp, [ebp]
-        add	ebp, ecx
-
-        movdqa	xmm7, [QDI + QCX]
-        movdqa[esp + 8h], xmm0
-        movdqa[esp + 18h], xmm6
-        movdqa[esp + 28h], xmm1
-        movdqa[esp + 38h], xmm2
-        movdqa[esp + 48h], xmm3
-        movdqa[esp + 58h], xmm4
-#else
-        movsx_int	rbp, edg_pitchn
-        mov	r8, rax                     // save to R8
-        add	rbp, rcx
-        movdqa	xmm7, [rdi + rcx]       
-        movdqa	xmm8, xmm0	// [rsp+ 8h]
-        movdqa	xmm9, xmm6	// [rsp+18h]
-        movdqa	xmm10, xmm1	// [rsp+28h]
-        movdqa	xmm11, xmm2	// [rsp+38h]
-        movdqa	xmm12, xmm3	// [rsp+48h]
-        movdqa	xmm13, xmm4	// [rsp+58h]
-#endif
-        movdqa	xmm1, xmm7
-        pslldq	xmm7, 7
-        punpcklqdq	xmm7, xmm1
-        psrldq	xmm1, 1
-        psrldq	xmm7, 7
-        test	g_cpuid, CPUF_SSSE3
-        jnz	l3
-        psrlw	xmm5, 8
-        align	10h
-        // SSE2 version
-        l2 :
-        movq	xmm4, qword ptr[QDI + QBX]
-          movq	xmm2, qword ptr[QDI + QBP]
-          pxor	xmm3, xmm3
-          punpcklbw	xmm7, xmm3
-          punpcklbw	xmm1, xmm3
-          punpcklbw	xmm4, xmm3
-          punpcklbw	xmm2, xmm3
-          psubw	xmm7, xmm1
-          psubw	xmm4, xmm2
-          psllw	xmm7, 7
-          psllw	xmm4, 7
-          pmulhw	xmm7, xmm6 // depth
-          pmulhw	xmm4, xmm6 // depth
-#if defined(X86_32)
-          movdqa	xmm6, [esp + 8h] // preload 1 src_pitch
-          pmaxsw	xmm4, [esp + 28h] // y_limit_min
-          pminsw	xmm4, [esp + 38h] // y_limit_max
-#else
-          movdqa	xmm6, xmm8	// preload 1 src_pitch
-          pmaxsw	xmm4, xmm10	// y_limit_min
-          pminsw	xmm4, xmm11	// y_limit_max
-#endif
-          pcmpeqw	xmm3, xmm3
-          psrlw	xmm3, 9
-          movdqa	xmm1, xmm7
-          movdqa	xmm2, xmm4
+      asm volatile ( \
+        "mov        %[psrc], %%rsi          \n\t" \
+        "mov        %[pedg], %%rcx          \n\t" \
+        "mov        %[pdst], %%rax          \n\t" \
+        "movsxd     %[src_pitch], %%rdx     \n\t" \
+        "movsxd     %[edg_pitchp], %%rbx    \n\t" \
+        "movsxd     %[i], %%rdi             \n\t" \
+        "sub        $0x08, %%rax            \n\t" \
+        "add        %%rsi, %%rdx            \n\t" \
+        "add        %%rcx, %%rbx            \n\t" \
+    : \
+    : [psrc] "r" (psrc), [pedg] "r" (pedg), [pdst] "r" (pdst), [src_pitch] "r" (src_pitch), [edg_pitchp] "r" (edg_pitchp), [i] "r" (i) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbx", "%rcx", "%rdx" );
+      asm volatile ( \
+        "movd       (%[y_limit_min]), %%xmm1  \n\t" \
+        "movd       (%[y_limit_max]), %%xmm2  \n\t" \
+        "movdqu     (%[x_limit_min]), %%xmm3  \n\t" \
+        "movdqu     (%[x_limit_max]), %%xmm4  \n\t" \
+        "movd       (%[depth]), %%xmm6        \n\t" \
+        "movd       (%[src_pitch]), %%xmm0    \n\t" \
+        "pcmpeqw    %%xmm7, %%xmm7          \n\t" \
+        "psrlw      $0x0f, %%xmm7           \n\t" \
+        "punpcklwd  %%xmm7, %%xmm0           \n\t" \
+        "pshufd     $0, %%xmm1, %%xmm1      \n\t" \
+        "pshufd     $0, %%xmm2, %%xmm2      \n\t" \
+        "pshufd     $0, %%xmm6, %%xmm6      \n\t" \
+        "pshufd     $0, %%xmm0, %%xmm0      \n\t" \
+        "packssdw   %%xmm1, %%xmm1          \n\t" \
+        "packssdw   %%xmm2, %%xmm2          \n\t" \
+        "packssdw   %%xmm6, %%xmm6          \n\t" \
+        "pcmpeqw    %%xmm5, %%xmm5          \n\t" \
+        "psllw      $0x0f, %%xmm5           \n\t" \
+        "push       %%rbp                   \n\t" \
+        "movsxd     %[edg_pitchn], %%rbp    \n\t" \
+        "mov        %%rax, %%r8             \n\t" \
+        "add        %%rcx, %%rbp            \n\t" \
+        "movdqa     (%%rdi,%%rcx), %%xmm7   \n\t" \
+        "movdqa     %%xmm0, %%xmm8          \n\t" \
+        "movdqa     %%xmm6, %%xmm9          \n\t" \
+        "movdqa     %%xmm1, %%xmm10         \n\t" \
+        "movdqa     %%xmm2, %%xmm11         \n\t" \
+        "movdqa     %%xmm3, %%xmm12         \n\t" \
+        "movdqa     %%xmm4, %%xmm13         \n\t" \
+        "movdqa     %%xmm7, %%xmm1          \n\t" \
+        "pslldq     $7, %%xmm7              \n\t" \
+        "punpcklqdq %%xmm1, %%xmm7          \n\t" \
+        "psrldq     $1, %%xmm1              \n\t" \
+        "psrldq     $7, %%xmm7              \n\t" \
+        /*"test      %[CPUF_SSSE3], %[g_cpuid] \n\t"*/ \
+        "jnz        29f                     \n\t" \
+        "psrlw      $8, %%xmm5              \n\t" \
+        ".align     0x10                    \n\t" \
+        "12:                                \n\t" \
+        "movq       (%%rdi,%%rbx), %%xmm4   \n\t" \
+        "movq       (%%rdi,%%rbp), %%xmm2   \n\t" \
+        "pxor       %%xmm3, %%xmm3          \n\t" \
+        "punpcklbw  %%xmm3, %%xmm7          \n\t" \
+        "punpcklbw  %%xmm3, %%xmm1          \n\t" \
+        "punpcklbw  %%xmm3, %%xmm4          \n\t" \
+        "punpcklbw  %%xmm3, %%xmm2          \n\t" \
+        "psubw      %%xmm1, %%xmm7          \n\t" \
+        "psubw      %%xmm2, %%xmm4          \n\t" \
+        "psllw      $7, %%xmm7              \n\t" \
+        "psllw      $7, %%xmm4              \n\t" \
+        "pmulhw     %%xmm6, %%xmm7          \n\t" \
+        "pmulhw     %%xmm6, %%xmm4          \n\t" \
+        "movdqa     %%xmm8, %%xmm6          \n\t" \
+        "pmaxsw     %%xmm10, %%xmm4         \n\t" \
+        "pminsw     %%xmm11, %%xmm4         \n\t" \
+        "pcmpeqw    %%xmm3, %%xmm3          \n\t" \
+        "psrlw      $9, %%xmm3              \n\t" \
+        "movdqa     %%xmm7, %%xmm1          \n\t" \
+        "movdqa     %%xmm4, %%xmm2          \n\t" \
+    : \
+    : [y_limit_min] "r" (y_limit_min), [y_limit_max] "r" (y_limit_max), [x_limit_min] "r" (x_limit_min), [x_limit_max] "r" (x_limit_max),
+      [depth] "r" (depth), [src_pitch] "r" (src_pitch), [edg_pitchn] "r" (edg_pitchn) \
+    : "memory", "cc", "%r8", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7",
+      "%xmm8", "%xmm9", "%xmm10", "%xmm11", "%xmm12", "%xmm13" );
 #if SMAGL
-          psllw	xmm4, SMAGL
-          psllw	xmm7, SMAGL
+      asm volatile ( \
+        "psllw      (%[smagl]), %%xmm4      \n\t" \
+        "psllw      (%[smagl]), %%xmm7      \n\t" \
+    : \
+    : [smagl] "r" ((int)SMAGL) \
+    : "memory", "cc", "%xmm4", "%xmm7" );
 #endif
-          pand	xmm7, xmm3 // 007F
-          pand	xmm4, xmm3 // 007F
-          psraw	xmm1, 7 - SMAGL
-          psraw	xmm2, 7 - SMAGL
-
-          movd	xmm3, edi
-          pshufd	xmm3, xmm3, 0
+      asm volatile ( \
+        "pand       %%xmm3, %%xmm7          \n\t" \
+        "pand       %%xmm3, %%xmm4          \n\t" \
+        "psraw      (%[smagl7]), %%xmm1     \n\t" \
+        "psraw      (%[smagl7]), %%xmm2     \n\t" \
+        "movd       %%edi, %%xmm3           \n\t" \
+        "pmaxsw     %%xmm2, %%xmm1          \n\t" \
+    : \
+    : [smagl7] "r" (7-(int)SMAGL) \
+    : "memory", "cc", "%edi", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm7" );
 #if SMAGL
-          pslld	xmm3, SMAGL
+      asm volatile ( \
+        "pslld      (%[smagl]), %%xmm3      \n\t" \
+    : \
+    : [smagl] "r" ((int)SMAGL) \
+    : "memory", "cc", "%xmm3" );
 #endif
-          packssdw	xmm3, xmm3
-          paddsw	xmm1, xmm3
-
-#if defined(X86_32)
-          movdqa	xmm3, [esp + 58h] // x_limit_max
-          movdqa	xmm0, [esp + 48h] // x_limit_min
-#else
-          movdqa	xmm3, xmm13	// x_limit_max
-          movdqa	xmm0, xmm12	// x_limit_min
-#endif
-          pcmpgtw	xmm3, xmm1
-          pcmpgtw	xmm0, xmm1
-#if defined(X86_32)
-          pminsw	xmm1, [esp + 58h] // x_limit_max
-          pmaxsw	xmm1, [esp + 48h] // x_limit_min
-#else
-          pminsw	xmm1, xmm13	// x_limit_max
-          pmaxsw	xmm1, xmm12	// x_limit_min
-#endif
-          pand	xmm7, xmm3
-          pandn	xmm0, xmm7
-
-          movdqa	xmm7, xmm2
-          punpcklwd	xmm2, xmm1
-          punpckhwd	xmm7, xmm1
-          pmaddwd	xmm2, xmm6 // 1 src_pitch
-          pmaddwd	xmm7, xmm6 // 1 src_pitch
-
-          movd	eax, xmm2
-          psrldq	xmm2, 4
-          pinsrw	xmm3, [QAX + QSI], 0
-          pinsrw	xmm1, [QAX + QDX], 0
-          movd	eax, xmm2
-          psrldq	xmm2, 4
-          pinsrw	xmm3, [QAX + QSI + 1 * SMAG], 1
-          pinsrw	xmm1, [QAX + QDX + 1 * SMAG], 1
-          movd	eax, xmm2
-          psrldq	xmm2, 4
-          pinsrw	xmm3, [QAX + QSI + 2 * SMAG], 2
-          pinsrw	xmm1, [QAX + QDX + 2 * SMAG], 2
-          movd	eax, xmm2
-          pinsrw	xmm3, [QAX + QSI + 3 * SMAG], 3
-          pinsrw	xmm1, [QAX + QDX + 3 * SMAG], 3
-          movd	eax, xmm7
-          psrldq	xmm7, 4
-          pinsrw	xmm3, [QAX + QSI + 4 * SMAG], 4
-          pinsrw	xmm1, [QAX + QDX + 4 * SMAG], 4
-          movd	eax, xmm7
-          psrldq	xmm7, 4
-          pinsrw	xmm3, [QAX + QSI + 5 * SMAG], 5
-          pinsrw	xmm1, [QAX + QDX + 5 * SMAG], 5
-          movd	eax, xmm7
-          psrldq	xmm7, 4
-          pinsrw	xmm3, [QAX + QSI + 6 * SMAG], 6
-          pinsrw	xmm1, [QAX + QDX + 6 * SMAG], 6
-          movd	eax, xmm7
-          pinsrw	xmm3, [QAX + QSI + 7 * SMAG], 7
-          pinsrw	xmm1, [QAX + QDX + 7 * SMAG], 7
-#if defined(X86_32)
-          mov	eax, [esp + 4]
-#else
-          mov	rax, r8    // restore rax
-#endif
-
-          pcmpeqw	xmm6, xmm6
-          movdqa	xmm2, xmm3
-          psrlw	xmm6, 8
-          movdqa	xmm7, xmm1
-          pand	xmm3, xmm6 // 00FF
-          pand	xmm1, xmm6 // 00FF
-          movdqa	xmm6, xmm5
-          psubw	xmm6, xmm0
-          pmullw	xmm3, xmm6
-          pmullw	xmm1, xmm6
-          movdqa	xmm6, xmm5 // 0080
-          psrlw	xmm5, 1
-          psrlw	xmm2, 8
-          psrlw	xmm7, 8
-          pmullw	xmm2, xmm0
-          pmullw	xmm7, xmm0
-          paddw	xmm3, xmm2
-          paddw	xmm1, xmm7
-          paddw	xmm3, xmm5 // 0040
-          paddw	xmm1, xmm5 // 0040
-          psraw	xmm3, 7
-          psraw	xmm1, 7
-
-          psubw	xmm6, xmm4
-          movdqu	xmm7, [QDI + QCX + 7]
-          pmullw	xmm1, xmm4
-          pmullw	xmm3, xmm6
-          paddw	xmm3, xmm1
-          movdqa	xmm1, xmm7
-#if defined(X86_32)
-            movdqa	xmm6, [esp + 18h] // preload depth
-#else
-            movdqa	xmm6, xmm9	// preload depth
-#endif
-
-          paddw	xmm3, xmm5 // 0040
-          psrldq	xmm1, 2
-          psraw	xmm3, 7
-          paddw	xmm5, xmm5
-          packuswb	xmm3, xmm3
-          add	QDI, 8
-          jg	ls
-          movq	qword ptr[QDI + QAX], xmm3
-          jnz	l2
-          jmp	lx
-          align	10h
-          // SSSE3 version (pmaddubsw, psignw, palignr)
-          l3 :
-        movq	xmm4, qword ptr[QDI + QBX]
-          movq	xmm2, qword ptr[QDI + QBP]
-          pxor	xmm0, xmm0
-          punpcklbw	xmm7, xmm0
-          punpcklbw	xmm1, xmm0
-          punpcklbw	xmm4, xmm0
-          punpcklbw	xmm2, xmm0
-          psubw	xmm7, xmm1
-          psubw	xmm4, xmm2
-          psllw	xmm7, 7
-          psllw	xmm4, 7
-          pmulhw	xmm7, xmm6 // depth
-          pmulhw	xmm4, xmm6 // depth
-          movd	xmm6, edi // preload
-#if defined(X86_32)
-          pmaxsw	xmm4, [esp + 28h] // y_limit_min
-          pminsw	xmm4, [esp + 38h] // y_limit_max
-#else
-          pmaxsw	xmm4, xmm10	// y_limit_min
-          pminsw	xmm4, xmm11	// y_limit_max
-#endif
-
-          pshufd	xmm6, xmm6, 0
+      asm volatile ( \
+        "packssdw   %%xmm3, %%xmm3          \n\t" \
+        "paddsw     %%xmm3, %%xmm1          \n\t" \
+        "movdqa     %%xmm13, %%xmm3          \n\t" \
+        "movdqa     %%xmm12, %%xmm0          \n\t" \
+        "pcmpgtw    %%xmm1, %%xmm3          \n\t" \
+        "pcmpgtw    %%xmm1, %%xmm0          \n\t" \
+        "pminsw     %%xmm13, %%xmm1          \n\t" \
+        "pmaxsw     %%xmm12, %%xmm1          \n\t" \
+        "pand       %%xmm3, %%xmm7          \n\t" \
+        "pandn      %%xmm7, %%xmm0          \n\t" \
+        "movdqa     %%xmm2, %%xmm7          \n\t" \
+        "punpcklwd  %%xmm1, %%xmm2          \n\t" \
+        "punpckhwd  %%xmm1, %%xmm7          \n\t" \
+        "pmaddwd	%%xmm6, %%xmm2          \n\t" \
+        "pmaddwd	%%xmm6, %%xmm7          \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "pinsrw     $0, (%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $0, (%%rax,%%rdx), %%xmm1 \n\t" \
+    : \
+    : \
+    : "memory", "cc", "%eax", "%rax", "%rdx", "%rsi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",
+      "%xmm5", "%xmm6", "%xmm7", "%xmm8", "%xmm9", "%xmm10", "%xmm11", "%xmm12", "%xmm13" );
 #if SMAGL
-          pslld	xmm6, SMAGL
+      asm volatile ( \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "pinsrw     $1, 0x01(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $1, 0x01(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "pinsrw     $2, 0x02(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $2, 0x02(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "pinsrw     $3, 0x03(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $3, 0x03(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "pinsrw     $4, 0x04(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $4, 0x04(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "pinsrw     $5, 0x05(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $5, 0x05(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "pinsrw     $6, 0x06(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $6, 0x06(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "pinsrw     $7, 0x07(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $7, 0x07(%%rax,%%rdx), %%xmm1 \n\t" \
+    : \
+    : \
+    : "memory", "cc", "%eax", "%rax", "%rdx", "%rsi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",
+      "%xmm5", "%xmm6", "%xmm7", "%xmm8", "%xmm9", "%xmm10", "%xmm11", "%xmm12", "%xmm13" );
+#else
+      asm volatile ( \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "pinsrw     $1, 1(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $1, 1(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "pinsrw     $2, 2(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $2, 2(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "pinsrw     $3, 3(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $3, 3(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "pinsrw     $4, 4(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $4, 4(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "pinsrw     $5, 5(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $5, 5(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "pinsrw     $6, 6(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $6, 6(%%rax,%%rdx), %%xmm1 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "pinsrw     $7, 7(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $7, 7(%%rax,%%rdx), %%xmm1 \n\t" \
+    : \
+    : \
+    : "memory", "cc", "%eax", "%rax", "%rdx", "%rsi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",
+      "%xmm5", "%xmm6", "%xmm7", "%xmm8", "%xmm9", "%xmm10", "%xmm11", "%xmm12", "%xmm13" );
 #endif
-
-          pcmpeqw	xmm0, xmm0
-          psrlw	xmm0, 9
-          movdqa	xmm2, xmm4
-          movdqa	xmm1, xmm7
+      asm volatile ( \
+        "mov        %%r8, %%rax             \n\t" \
+        "pcmpeqw    %%xmm6, %%xmm6          \n\t" \
+        "movdqa     %%xmm3, %%xmm2          \n\t" \
+        "psrlw      $8, %%xmm6              \n\t" \
+        "movdqa     %%xmm1, %%xmm7          \n\t" \
+        "pand       %%xmm6, %%xmm3          \n\t" \
+        "pand       %%xmm6, %%xmm1          \n\t" \
+        "movdqa     %%xmm5, %%xmm6          \n\t" \
+        "psubw      %%xmm0, %%xmm6          \n\t" \
+        "pmullw     %%xmm6, %%xmm3          \n\t" \
+        "pmullw     %%xmm6, %%xmm1          \n\t" \
+        "movdqa     %%xmm5, %%xmm6          \n\t" \
+        "psrlw      $1, %%xmm5              \n\t" \
+        "psrlw      $8, %%xmm2              \n\t" \
+        "psrlw      $8, %%xmm7              \n\t" \
+        "pmullw     %%xmm0, %%xmm2          \n\t" \
+        "pmullw     %%xmm0, %%xmm7          \n\t" \
+        "paddw      %%xmm2, %%xmm3          \n\t" \
+        "paddw      %%xmm7, %%xmm1          \n\t" \
+        "paddw      %%xmm5, %%xmm3          \n\t" \
+        "paddw      %%xmm5, %%xmm1          \n\t" \
+        "psraw      $7, %%xmm3              \n\t" \
+        "psraw      $7, %%xmm1              \n\t" \
+        "psubw      %%xmm4, %%xmm6          \n\t" \
+        "movdqu     7(%%rdi,%%rcx), %%xmm7  \n\t" \
+        "pmullw     %%xmm4, %%xmm1          \n\t" \
+        "pmullw     %%xmm6, %%xmm3          \n\t" \
+        "paddw      %%xmm1, %%xmm3          \n\t" \
+        "movdqa     %%xmm7, %%xmm1          \n\t" \
+        "movdqa     %%xmm9, %%xmm6          \n\t" \
+        "paddw      %%xmm5, %%xmm3          \n\t" \
+        "psrldq     $2, %%xmm1              \n\t" \
+        "psraw      $7, %%xmm3              \n\t" \
+        "paddw      %%xmm5, %%xmm5          \n\t" \
+        "packuswb   %%xmm3, %%xmm3          \n\t" \
+        "add        $8, %%rdi               \n\t" \
+        "jg         30f                     \n\t" \
+        "movq       %%xmm3, (%%rdi,%%rax)   \n\t" \
+        "jnz        12b                     \n\t" \
+        "jmp        31f                     \n\t" \
+        ".align     0x10                    \n\t" \
+        "29:                                \n\t" \
+        "movq       (%%rdi,%%rbx), %%xmm4   \n\t" \
+        "movq       (%%rdi,%%rbp), %%xmm2   \n\t" \
+        "pxor       %%xmm0, %%xmm0          \n\t" \
+        "punpcklbw  %%xmm0, %%xmm7          \n\t" \
+        "punpcklbw  %%xmm0, %%xmm1          \n\t" \
+        "punpcklbw  %%xmm0, %%xmm4          \n\t" \
+        "punpcklbw  %%xmm0, %%xmm2          \n\t" \
+        "psubw      %%xmm1, %%xmm7          \n\t" \
+        "psubw      %%xmm2, %%xmm4          \n\t" \
+        "psllw      $7, %%xmm7              \n\t" \
+        "psllw      $7, %%xmm4              \n\t" \
+        "pmulhw     %%xmm6, %%xmm7          \n\t" \
+        "pmulhw     %%xmm6, %%xmm4          \n\t" \
+        "movd       %%edi, %%xmm6           \n\t"
+        "pmaxsw     %%xmm10, %%xmm4         \n\t" \
+        "pminsw     %%xmm11, %%xmm4         \n\t" \
+        "pshufd     $0, %%xmm6, %%xmm6      \n\t" \
+    : \
+    : \
+    : "memory", "cc", "%edi", "%r8", "%rbp", "%rdi", "%rax", "%rbx", "%rcx", "%rdx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",
+      "%xmm5", "%xmm6", "%xmm7", "%xmm8", "%xmm9", "%xmm10", "%xmm11", "%xmm12", "%xmm13" );
 #if SMAGL
-          psllw	xmm4, SMAGL
-          psllw	xmm7, SMAGL
+      asm volatile ( \
+        "pslld      (%[smagl]), %%xmm6      \n\t" \
+    : \
+    : [smagl] "r" ((int)SMAGL) \
+    : "memory", "cc", "%xmm6" );
 #endif
-          pand	xmm4, xmm0 // 007F
-          pand	xmm7, xmm0 // 007F
-
-          psraw	xmm1, 7 - SMAGL
-          packssdw	xmm6, xmm6
-          paddsw	xmm1, xmm6
-#if defined(X86_32)
-          movdqa	xmm6, [esp + 8h] // preload 1 src_pitch
-
-          movdqa	xmm0, [esp + 58h] // x_limit_max
-          movdqa	xmm3, [esp + 48h] // x_limit_min
+      asm volatile ( \
+        "pcmpeqw    %%xmm0, %%xmm0          \n\t" \
+        "psrlw      $9, %%xmm0              \n\t" \
+        "movdqa     %%xmm4, %%xmm2          \n\t" \
+        "movdqa     %%xmm7, %%xmm1          \n\t" \
+    : \
+    : \
+    : "memory", "cc", "%xmm0", "%xmm1", "%xmm2", "%xmm4", "%xmm7" );
+#if SMAGL
+      asm volatile ( \
+        "psllw      (%[smagl]), %%xmm4      \n\t" \
+        "psllw      (%[smagl]), %%xmm7      \n\t" \
+    : \
+    : [smagl] "r" ((int)SMAGL) \
+    : "memory", "cc", "%xmm4", "%xmm7" );
+#endif
+      asm volatile ( \
+        "pand       %%xmm0, %%xmm4          \n\t" \
+        "pand       %%xmm0, %%xmm7          \n\t" \
+        "psraw      (%[smagl7]), %%xmm1     \n\t" \
+        "packssdw   %%xmm6, %%xmm6          \n\t" \
+        "paddsw     %%xmm6, %%xmm1          \n\t" \
+        "movdqa     %%xmm8, %%xmm6          \n\t" \
+        "movdqa     %%xmm13, %%xmm0         \n\t" \
+        "movdqa     %%xmm12, %%xmm3         \n\t" \
+        "pcmpgtw    %%xmm1, %%xmm0          \n\t" \
+        "pcmpgtw    %%xmm1, %%xmm3          \n\t" \
+        "pmaxsw     %%xmm13, %%xmm1         \n\t" \
+        "pminsw     %%xmm12, %%xmm1         \n\t" \
+        "pand       %%xmm0, %%xmm7          \n\t" \
+        "pandn      %%xmm7, %%xmm3          \n\t" \
+        "psraw      (%[smagl7]), %%xmm2     \n\t" \
+        "movdqa     %%xmm2, %%xmm7          \n\t" \
+        "punpcklwd  %%xmm1, %%xmm2          \n\t" \
+        "punpckhwd  %%xmm1, %%xmm7          \n\t" \
+        "pmaddwd	%%xmm6, %%xmm2          \n\t" \
+        "pmaddwd	%%xmm6, %%xmm7          \n\t" \
+        "movdqa     %%xmm9, %%xmm6          \n\t" \
+        "psignw     %%xmm5, %%xmm3          \n\t" \
+        "psignw     %%xmm5, %%xmm4          \n\t" \
+        "packsswb   %%xmm5, %%xmm5          \n\t" \
+        "packsswb   %%xmm3, %%xmm3          \n\t" \
+        "packsswb   %%xmm4, %%xmm4          \n\t" \
+        "movdqa     %%xmm5, %%xmm0          \n\t" \
+        "movdqa     %%xmm5, %%xmm1          \n\t" \
+        "psubb      %%xmm3, %%xmm0          \n\t" \
+        "psubb      %%xmm4, %%xmm1          \n\t" \
+        "psrlw      $9, %%xmm5              \n\t" \
+        "punpcklbw  %%xmm3, %%xmm0          \n\t" \
+        "punpcklbw  %%xmm4, %%xmm1          \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $0, (%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $0, (%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+    : \
+    : [smagl7] "r" (7-(int)SMAGL) \
+    : "memory", "cc", "%eax", "%rax", "%rdx", "%rsi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7", "%xmm8", "%xmm9", "%xmm12", "%xmm13" );
+#if SMAGL
+      asm volatile ( \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $1, 0x01(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $1, 0x01(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $2, 0x02(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $2, 0x02(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $3, 0x03(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $3, 0x03(%%rax,%%rdx), %%xmm4 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $4, 0x04(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $4, 0x04(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $5, 0x05(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $5, 0x05(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $6, 0x06(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $6, 0x06(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $7, 0x07(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $7, 0x07(%%rax,%%rdx), %%xmm4 \n\t" \
+    : \
+    : \
+    : "memory", "cc", "%eax", "%rax", "%rdx", "%rsi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",
+      "%xmm5", "%xmm6", "%xmm7" );
 #else
-          movdqa	xmm6, xmm8	// preload 1 src_pitch
-
-          movdqa	xmm0, xmm13	// x_limit_max
-          movdqa	xmm3, xmm12	// x_limit_min
+      asm volatile ( \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $1, 1(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $1, 1(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $2, 2(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $2, 2(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm2              \n\t" \
+        "movd       %%xmm2, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $3, 3(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $3, 3(%%rax,%%rdx), %%xmm4 \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $4, 4(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $4, 4(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $5, 5(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $5, 5(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $6, 6(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $6, 6(%%rax,%%rdx), %%xmm4 \n\t" \
+        "psrldq     $4, %%xmm7              \n\t" \
+        "movd       %%xmm7, %%eax           \n\t" \
+        "movsxd     %%eax, %%rax            \n\t" \
+        "pinsrw     $7, 7(%%rax,%%rsi), %%xmm3 \n\t" \
+        "pinsrw     $7, 7(%%rax,%%rdx), %%xmm4 \n\t" \
+    : \
+    : \
+    : "memory", "cc", "%eax", "%rax", "%rdx", "%rsi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",
+      "%xmm5", "%xmm6", "%xmm7" );
 #endif
-
-          pcmpgtw	xmm0, xmm1
-          pcmpgtw	xmm3, xmm1
-#if defined(X86_32)
-          pminsw	xmm1, [esp + 58h] // x_limit_max
-          pmaxsw	xmm1, [esp + 48h] // x_limit_min
-#else
-          pminsw	xmm1, xmm13	// x_limit_max
-          pmaxsw	xmm1, xmm12	// x_limit_min
-#endif
-          pand	xmm7, xmm0
-          pandn	xmm3, xmm7
-
-          psraw	xmm2, 7 - SMAGL
-          movdqa	xmm7, xmm2
-          punpcklwd	xmm2, xmm1
-          punpckhwd	xmm7, xmm1
-          pmaddwd	xmm2, xmm6 // 1 src_pitch
-          pmaddwd	xmm7, xmm6 // 1 src_pitch
-#if defined(X86_32)
-          movdqa	xmm6, [esp + 18h] // preload depth
-#else
-          movdqa	xmm6, xmm9	// preload depth
-#endif
-
-          psignw	xmm3, xmm5 // 8000
-          psignw	xmm4, xmm5 // 8000
-          packsswb	xmm5, xmm5
-          packsswb	xmm3, xmm3
-          packsswb	xmm4, xmm4
-
-          movdqa	xmm0, xmm5 // 80
-          movdqa	xmm1, xmm5 // 80
-          psubb	xmm0, xmm3
-          psubb	xmm1, xmm4
-          psrlw	xmm5, 9
-          punpcklbw	xmm0, xmm3
-          punpcklbw	xmm1, xmm4
-
-          movd	eax, xmm2
-          SEXT(rax, eax)
-          pinsrw	xmm3, [QAX + QSI], 0
-          pinsrw	xmm4, [QAX + QDX], 0
-          psrldq	xmm2, 4
-          movd	eax, xmm2
-          SEXT(rax, eax)
-          pinsrw	xmm3, [QAX + QSI + 1 * SMAG], 1
-          pinsrw	xmm4, [QAX + QDX + 1 * SMAG], 1
-          psrldq	xmm2, 4
-          movd	eax, xmm2
-          SEXT(rax, eax)
-          pinsrw	xmm3, [QAX + QSI + 2 * SMAG], 2
-          pinsrw	xmm4, [QAX + QDX + 2 * SMAG], 2
-          psrldq	xmm2, 4
-          movd	eax, xmm2
-          SEXT(rax, eax)
-          pinsrw	xmm3, [QAX + QSI + 3 * SMAG], 3
-          pinsrw	xmm4, [QAX + QDX + 3 * SMAG], 3
-          movd	eax, xmm7
-          SEXT(rax, eax)
-          pinsrw	xmm3, [QAX + QSI + 4 * SMAG], 4
-          pinsrw	xmm4, [QAX + QDX + 4 * SMAG], 4
-          psrldq	xmm7, 4
-          movd	eax, xmm7
-          SEXT(rax, eax)
-          pinsrw	xmm3, [QAX + QSI + 5 * SMAG], 5
-          pinsrw	xmm4, [QAX + QDX + 5 * SMAG], 5
-          psrldq	xmm7, 4
-          movd	eax, xmm7
-          SEXT(rax, eax)
-          pinsrw	xmm3, [QAX + QSI + 6 * SMAG], 6
-          pinsrw	xmm4, [QAX + QDX + 6 * SMAG], 6
-          psrldq	xmm7, 4
-          movd	eax, xmm7
-          SEXT(rax, eax)
-          pinsrw	xmm3, [QAX + QSI + 7 * SMAG], 7
-          pinsrw	xmm4, [QAX + QDX + 7 * SMAG], 7
-
-          pcmpeqw	xmm2, xmm2
-          movdqu	xmm7, [QDI + QCX + 7]
-          pmaddubsw	xmm3, xmm0
-          pmaddubsw	xmm4, xmm0
-#if defined(X86_32)
-          mov	eax, [esp + 4]
-#else
-          mov	rax, r8
-#endif
-          psignw	xmm3, xmm2
-          psignw	xmm4, xmm2
-          paddw	xmm3, xmm5 // 0040
-          paddw	xmm4, xmm5 // 0040
-          psraw	xmm3, 7
-          psraw	xmm4, 7
-          packuswb	xmm3, xmm3
-          packuswb	xmm4, xmm4
-          punpcklbw	xmm3, xmm4
-          pmaddubsw	xmm3, xmm1
-          palignr	xmm1, xmm7, 2
-          psignw	xmm3, xmm2
-
-          paddw	xmm3, xmm5 // 0040
-          psraw	xmm3, 7
-          psllw	xmm5, 9
-          packuswb	xmm3, xmm3
-          add	QDI, 8
-          jg	ls
-          movq	qword ptr[QDI + QAX], xmm3
-          jnz	l3
-          jmp	lx
-        ls :
-          movd[QDI + QAX], xmm3
-        lx :
-#if defined(X86_32)
-          pop	QSP
-          pop	QCX
-#endif
-          pop	QBP
-      }*/
+      asm volatile ( \
+        "pcmpeqw    %%xmm2, %%xmm2          \n\t" \
+        "movdqu     7(%%rdi,%%rcx), %%xmm7  \n\t" \
+        "pmaddubsw  %%xmm0, %%xmm3          \n\t" \
+        "pmaddubsw  %%xmm0, %%xmm4          \n\t" \
+        "mov        %%r8, %%rax             \n\t" \
+        "psignw     %%xmm2, %%xmm3          \n\t" \
+        "psignw     %%xmm2, %%xmm4          \n\t" \
+        "paddw      %%xmm5, %%xmm3          \n\t" \
+        "paddw      %%xmm5, %%xmm4          \n\t" \
+        "psraw      $7, %%xmm3              \n\t" \
+        "psraw      $7, %%xmm4              \n\t" \
+        "packuswb   %%xmm3, %%xmm3          \n\t" \
+        "packuswb   %%xmm4, %%xmm4          \n\t" \
+        "punpcklbw  %%xmm4, %%xmm3          \n\t" \
+        "pmaddubsw  %%xmm1, %%xmm3          \n\t" \
+        "palignr    $2, %%xmm7, %%xmm1      \n\t" \
+        "psignw     %%xmm2, %%xmm3          \n\t" \
+        "paddw      %%xmm5, %%xmm3          \n\t" \
+        "psraw      $7, %%xmm3              \n\t" \
+        "psllw      $9, %%xmm5              \n\t" \
+        "packuswb   %%xmm3, %%xmm3          \n\t" \
+        "add        $8, %%rdi               \n\t" \
+        "jg         30f                     \n\t" \
+        "movq       %%xmm3, (%%rdi,%%rax)   \n\t" \
+        "jnz        29b                     \n\t" \
+        "jmp        31f                     \n\t" \
+        "30:                                \n\t" \
+        "movd       %%xmm3, (%%rdi,%%rax)   \n\t" \
+        "31:                                \n\t" \
+        "pop        %%rbp                   \n\t" \
+    : \
+    : \
+    : "memory", "cc", "%eax", "%r8", "%rbp", "%rax", "%rcx", "%rdi", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4",
+      "%xmm5", "%xmm6", "%xmm7" );
       psrc += src_pitch*SMAG;
       pedg += edg_pitch;
       pdst += dst_pitch;

--- a/src/aWarpSharp.cpp
+++ b/src/aWarpSharp.cpp
@@ -22,7 +22,7 @@
 #include <cassert>
 #include <algorithm>
 
-__declspec(align(16)) static const unsigned char dq0toF[0x10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+__attribute__((aligned(16))) static const unsigned char dq0toF[0x10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 
 int g_cpuid;
 
@@ -75,11 +75,11 @@ void Sobel(PVideoFrame &src, PVideoFrame &dst, int plane, int thresh, const Vide
   const int padded_div4_rowsize = (dst_row_size + 3) >> 2;
   const int i = padded_div4_rowsize; // for asm
 
-  if (g_cpuid & CPUF_SSE2)
+  if (!(g_cpuid & CPUF_SSE2))
     // SSE2 version
     for (int y = 0; y < height; y++)
     {
-#if 1 // def _M_X64
+#if 0 // def _M_X64
       // 0: prev=0 curr = 0 next = 1
       // y-1: prev = y-2, curr = y-1, next = y-1
       // else between: prev = y-1, curr = y, next = y+1
@@ -165,94 +165,90 @@ void Sobel(PVideoFrame &src, PVideoFrame &dst, int plane, int thresh, const Vide
           }
         }
 #else
-      __asm {
-        mov	QSI, psrc
-        mov	QDI, pdst
-        movsx_int	QDX, src_pitch
-        xor	QAX, QAX
-        movsx_int	QCX, y
-        test	QCX, QCX
-        cmovnz	QAX, QDX
-        inc	QCX
-        add	QDX, QAX
-        cmp	ecx, height     // 32 bit O.K.
-        cmovz	QDX, QAX
-        sub	QSI, QAX
-        movsx_int	QCX, i
-        sub	QDI, 10h
-        sub	QDI, QSI
-        movd	xmm0, thresh
-        pshufd	xmm0, xmm0, 0
-        packssdw	xmm0, xmm0
-        packuswb	xmm0, xmm0
-        align	10h
-        l :
-        movdqu	xmm2, [QSI - 1]
-          movdqu	xmm3, [QSI]
-          movdqu	xmm4, [QSI + 1]
-          movdqu	xmm5, [QSI + QDX - 1]
-          movdqu	xmm6, [QSI + QDX]
-          movdqu	xmm7, [QSI + QDX + 1]
-
-          movdqa	xmm1, xmm2
-          pavgb	xmm1, xmm4
-          pavgb	xmm3, xmm1
-
-          movdqa	xmm1, xmm5
-          pavgb	xmm1, xmm7
-          pavgb	xmm6, xmm1
-
-          movdqa	xmm1, xmm3
-          psubusb	xmm3, xmm6
-          psubusb	xmm6, xmm1
-          por	xmm6, xmm3
-
-          movdqu	xmm1, [QSI + QAX - 1]
-          movdqu	xmm3, [QSI + QAX + 1]
-          pavgb	xmm5, xmm2
-          pavgb	xmm7, xmm4
-          pavgb	xmm1, xmm5
-          pavgb	xmm3, xmm7
-          movdqa	xmm5, xmm1
-          psubusb	xmm1, xmm3
-          psubusb	xmm3, xmm5
-          por	xmm1, xmm3
-
-          movdqa	xmm2, xmm6
-          paddusb	xmm2, xmm1
-          pmaxub	xmm1, xmm6
-          paddusb	xmm2, xmm1
-
-          movdqa	xmm3, xmm2
-          paddusb	xmm2, xmm2
-          paddusb	xmm2, xmm3
-          paddusb	xmm2, xmm2
-          pminub	xmm2, xmm0 // thresh
-          add	QSI, 10h
-          sub	QCX, 4
-          jb	le1
-          movntdq[QSI + QDI], xmm2
-          jnz	l
-          jmp	lx
-          le1 :
-        test	QCX, 2
-          jz	le2
-          movq	qword ptr[QSI + QDI], xmm2
-          test	QCX, 1
-          jz	lx
-          add	QSI, 8
-          psrldq	xmm2, 8
-          le2:
-        movd[QSI + QDI], xmm2
-          lx :
-      }
+      asm volatile ( \
+        "mov       %[psrc], %%rsi          \n\t" \
+        "mov       %[pdst], %%rdi          \n\t" \
+        "movsxd    %[src_pitch], %%rdx     \n\t" \
+        "xor       %%rax, %%rax            \n\t" \
+        "movsxd    %[y], %%rcx             \n\t" \
+        "test      %%rcx, %%rcx            \n\t" \
+        "cmovnz    %%rdx, %%rax            \n\t" \
+        "inc       %%rcx                   \n\t" \
+        "add       %%rax, %%rdx            \n\t" \
+        "cmp       %[height], %%ecx        \n\t" \
+        "cmovz     %%rax, %%rdx            \n\t" \
+        "sub       %%rax, %%rsi            \n\t" \
+        "movsxd    %[i], %%rcx             \n\t" \
+        "sub       $0x10, %%rdi            \n\t" \
+        "sub       %%rsi, %%rdi            \n\t" \
+        "movd      %[thresh], %%xmm0        \n\t" \
+        "pshufd    $0, %%xmm0, %%xmm0      \n\t" \
+        "packssdw  %%xmm0, %%xmm0          \n\t" \
+        "packuswb  %%xmm0, %%xmm0          \n\t" \
+        ".align    0x10                   \n\t" \
+        "1:                                \n\t" \
+        "movdqu    -1(%%rsi), %%xmm2      \n\t" \
+        "movdqu    (%%rsi), %%xmm3          \n\t" \
+        "movdqu    1(%%rsi), %%xmm4       \n\t" \
+        "movdqu    -1(%%rsi), %%xmm5      \n\t" \
+        "movdqu    (%%rsi), %%xmm6          \n\t" \
+        "movdqu    1(%%rsi,%%rdx), %%xmm7 \n\t" \
+        "movdqa    %%xmm2, %%xmm1          \n\t" \
+        "pavgb     %%xmm4, %%xmm1          \n\t" \
+        "pavgb     %%xmm1, %%xmm3          \n\t" \
+        "movdqa    %%xmm5, %%xmm1          \n\t" \
+        "pavgb     %%xmm7, %%xmm1          \n\t" \
+        "pavgb     %%xmm1, %%xmm6          \n\t" \
+        "movdqa    %%xmm3, %%xmm1          \n\t" \
+        "psubusb   %%xmm6, %%xmm3          \n\t" \
+        "psubusb   %%xmm1, %%xmm6          \n\t" \
+        "por       %%xmm3, %%xmm6          \n\t" \
+        "movdqu    -1(%%rsi,%%rax), %%xmm1\n\t" \
+        "movdqu    1(%%rsi,%%rax), %%xmm3 \n\t" \
+        "pavgb     %%xmm2, %%xmm5          \n\t" \
+        "pavgb     %%xmm4, %%xmm7          \n\t" \
+        "pavgb     %%xmm5, %%xmm1          \n\t" \
+        "pavgb     %%xmm7, %%xmm3          \n\t" \
+        "movdqa    %%xmm1, %%xmm5          \n\t" \
+        "psubusb   %%xmm3, %%xmm1          \n\t" \
+        "psubusb   %%xmm5, %%xmm3          \n\t" \
+        "por       %%xmm3, %%xmm1          \n\t" \
+        "movdqa    %%xmm6, %%xmm2          \n\t" \
+        "paddusb   %%xmm1, %%xmm2          \n\t" \
+        "pmaxub    %%xmm6, %%xmm1          \n\t" \
+        "paddusb   %%xmm1, %%xmm2          \n\t" \
+        "movdqa    %%xmm2, %%xmm3          \n\t" \
+        "paddusb   %%xmm2, %%xmm2          \n\t" \
+        "paddusb   %%xmm2, %%xmm3          \n\t" \
+        "paddusb   %%xmm2, %%xmm2          \n\t" \
+        "pminub    %%xmm0, %%xmm2          \n\t" \
+        "add       $0x10, %%rsi            \n\t" \
+        "sub       $4, %%rcx               \n\t" \
+        "jb 	   20f                    \n\t" \
+        "movntdq   %%xmm2, (%%rsi,%%rdi)   \n\t" \
+        "jnz	   1b                      \n\t" \
+        "jmp	   21f                     \n\t" \
+        "20:                              \n\t" \
+        "test      $2, %%rcx               \n\t" \
+        "jz        22f                    \n\t" \
+        "movq      %%xmm2, (%%rsi,%%rdi)   \n\t" \
+        "test      $1, %%rcx               \n\t" \
+        "jz 	   21f                     \n\t" \
+        "add       $8, %%rsi               \n\t" \
+        "psrldq    $8, %%xmm2              \n\t" \
+        "22:                              \n\t" \
+        "movd      %%xmm2, (%%rsi,%%rdi)   \n\t" \
+        "21:                               \n\t" \
+    : \
+    : [psrc] "r" (psrc), [pdst] "r" (pdst), [src_pitch] "r" (src_pitch), [y] "r" (y), [height] "m" (height), [i] "r" (i), [thresh] "r" (thresh) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
 #endif
       pdst[0] = pdst[1];
       pdst[dst_row_size - 1] = pdst[dst_row_size - 2];
       psrc += src_pitch;
       pdst += dst_pitch;
     }
-  __asm sfence;
+  asm volatile("sfence\n\t" : : : "memory", "cc");
 }
 
 // WxH min: 1x12, mul: 1x1 (write 16x1)
@@ -272,173 +268,177 @@ void BlurR6(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
   ptmp2 = ptmp;
   // Horizontal Blur
   // WxH min: 1x1, mul: 1x1 (write 16x1)
-  if (g_cpuid & CPUF_SSSE3) // SSSE?
+  if (!(g_cpuid & CPUF_SSSE3)) // SSSE?
     // SSSE3 version (palignr, pshufb)
     for (int y = 0; y < height; y++)
     {
-      __asm {
-        mov	QSI, psrc2
-        mov	QDI, ptmp2
-        movsx_int	QCX, i
-        add	QSI, 10h
-        sub	QDI, QSI
-        movdqa	xmm6, [QSI - 10h]
-        movdqa	xmm5, xmm6
-        movdqa	xmm7, xmm6
-        pxor	xmm0, xmm0
-        pshufb	xmm5, xmm0
-        sub	QCX, 10h
-        jna	l0e
-        align	10h
-        l0 :
-        movdqa	xmm7, [QSI]
-          movdqa	xmm0, xmm6
-          movdqa	xmm2, xmm7
-          palignr	xmm0, xmm5, 10
-          palignr	xmm2, xmm6, 6
-          pavgb	xmm0, xmm2
-          movdqa	xmm3, xmm6
-          movdqa	xmm4, xmm7
-          palignr	xmm3, xmm5, 11
-          palignr	xmm4, xmm6, 5
-          pavgb	xmm3, xmm4
-          pavgb	xmm0, xmm3
-          movdqa	xmm1, xmm6
-          movdqa	xmm2, xmm7
-          palignr	xmm1, xmm5, 12
-          palignr	xmm2, xmm6, 4
-          pavgb	xmm1, xmm2
-          movdqa	xmm3, xmm6
-          movdqa	xmm4, xmm7
-          palignr	xmm3, xmm5, 13
-          palignr	xmm4, xmm6, 3
-          pavgb	xmm3, xmm4
-          pavgb	xmm1, xmm3
-          pavgb	xmm0, xmm1
-          movdqa	xmm1, xmm6
-          movdqa	xmm2, xmm7
-          palignr	xmm1, xmm5, 14
-          palignr	xmm2, xmm6, 2
-          pavgb	xmm1, xmm2
-          movdqa	xmm3, xmm6
-          movdqa	xmm4, xmm7
-          palignr	xmm3, xmm5, 15
-          palignr	xmm4, xmm6, 1
-          pavgb	xmm3, xmm4
-          pavgb	xmm1, xmm3
-          pavgb	xmm1, xmm6
-          movdqa	xmm5, xmm6
-          movdqa	xmm6, xmm7
-          pavgb	xmm0, xmm1
-          pavgb	xmm0, xmm1
-          movntdq[QSI + QDI], xmm0
-          add	QSI, 10h
-          sub	QCX, 10h
-          ja	l0
-          l0e :
-        add	QCX, 0Fh
-          pxor	xmm0, xmm0
-          movd	xmm1, ecx
-          pshufb	xmm1, xmm0
-          pminub	xmm1, dq0toF // 0x0F0E..00
-          pshufb	xmm6, xmm1
-          psrldq	xmm7, 15
-          pshufb	xmm7, xmm0
-          movdqa	xmm0, xmm6
-          movdqa	xmm2, xmm7
-          palignr	xmm0, xmm5, 10
-          palignr	xmm2, xmm6, 6
-          pavgb	xmm0, xmm2
-          movdqa	xmm3, xmm6
-          movdqa	xmm4, xmm7
-          palignr	xmm3, xmm5, 11
-          palignr	xmm4, xmm6, 5
-          pavgb	xmm3, xmm4
-          pavgb	xmm0, xmm3
-          movdqa	xmm1, xmm6
-          movdqa	xmm2, xmm7
-          palignr	xmm1, xmm5, 12
-          palignr	xmm2, xmm6, 4
-          pavgb	xmm1, xmm2
-          movdqa	xmm3, xmm6
-          movdqa	xmm4, xmm7
-          palignr	xmm3, xmm5, 13
-          palignr	xmm4, xmm6, 3
-          pavgb	xmm3, xmm4
-          pavgb	xmm1, xmm3
-          pavgb	xmm0, xmm1
-          movdqa	xmm1, xmm6
-          movdqa	xmm2, xmm7
-          palignr	xmm1, xmm5, 14
-          palignr	xmm2, xmm6, 2
-          pavgb	xmm1, xmm2
-          movdqa	xmm3, xmm6
-          movdqa	xmm4, xmm7
-          palignr	xmm3, xmm5, 15
-          palignr	xmm4, xmm6, 1
-          pavgb	xmm3, xmm4
-          pavgb	xmm1, xmm3
-          pavgb	xmm1, xmm6
-          movdqa	xmm5, xmm6
-          movdqa	xmm6, xmm7
-          pavgb	xmm0, xmm1
-          pavgb	xmm0, xmm1
-          movntdq[QSI + QDI], xmm0
-      }
+      asm volatile ( \
+        "mov       %[psrc2], %%rsi         \n\t" \
+        "mov       %[ptmp2], %%rdi         \n\t" \
+        "movsxd    %[i], %%rcx             \n\t" \
+        "add       $0x10, %%rsi            \n\t" \
+        "sub       %%rsi, %%rdi            \n\t" \
+        "movdqa    -0x10(%%rsi), %%xmm6   \n\t" \
+        "movdqa    %%xmm6, %%xmm5          \n\t" \
+        "movdqa    %%xmm6, %%xmm7          \n\t" \
+        "pxor      %%xmm0, %%xmm0          \n\t" \
+        "pshufb    %%xmm0, %%xmm5          \n\t" \
+        "sub       $0x10, %%rsi            \n\t" \
+        "jna        23f                    \n\t" \
+        ".align      0x10                   \n\t" \
+        "2:                               \n\t" \
+        "movdqa    (%%rsi), %%xmm7           \n\t" \
+        "movdqa    %%xmm6, %%xmm0          \n\t" \
+        "movdqa    %%xmm7, %%xmm2          \n\t" \
+        "palignr	$10, %%xmm0, %%xmm5     \n\t" \
+        "palignr	$6, %%xmm2, %%xmm6      \n\t" \
+        "pavgb     %%xmm2, %%xmm0          \n\t" \
+        "movdqa    %%xmm6, %%xmm3          \n\t" \
+        "movdqa    %%xmm7, %%xmm4          \n\t" \
+        "palignr	$11, %%xmm3, %%xmm5     \n\t" \
+        "palignr	$5, %%xmm4, %%xmm6      \n\t" \
+        "pavgb     %%xmm4, %%xmm3          \n\t" \
+        "pavgb     %%xmm3, %%xmm0          \n\t" \
+        "movdqa    %%xmm6, %%xmm1          \n\t" \
+        "movdqa    %%xmm7, %%xmm2          \n\t" \
+        "palignr	$12, %%xmm1, %%xmm5     \n\t" \
+        "palignr	$4, %%xmm2, %%xmm6      \n\t" \
+        "pavgb     %%xmm2, %%xmm1          \n\t" \
+        "movdqa    %%xmm6, %%xmm3          \n\t" \
+        "movdqa    %%xmm7, %%xmm4          \n\t" \
+        "palignr	$13, %%xmm3, %%xmm5     \n\t" \
+        "palignr	$3, %%xmm4, %%xmm6      \n\t" \
+        "pavgb     %%xmm4, %%xmm3          \n\t" \
+        "pavgb     %%xmm3, %%xmm1          \n\t" \
+        "pavgb     %%xmm1, %%xmm0          \n\t" \
+        "movdqa    %%xmm6, %%xmm1          \n\t" \
+        "movdqa    %%xmm7, %%xmm2          \n\t" \
+        "palignr	$14, %%xmm1, %%xmm5     \n\t" \
+        "palignr	$2, %%xmm2, %%xmm6      \n\t" \
+        "pavgb     %%xmm2, %%xmm1          \n\t" \
+        "movdqa    %%xmm6, %%xmm3          \n\t" \
+        "movdqa    %%xmm7, %%xmm4          \n\t" \
+        "palignr	$15, %%xmm3, %%xmm5     \n\t" \
+        "palignr	$1, %%xmm4, %%xmm6      \n\t" \
+        "pavgb     %%xmm4, %%xmm3          \n\t" \
+        "pavgb     %%xmm3, %%xmm1          \n\t" \
+        "pavgb     %%xmm6, %%xmm1          \n\t" \
+        "movdqa    %%xmm6, %%xmm5          \n\t" \
+        "movdqa    %%xmm7, %%xmm6          \n\t" \
+        "pavgb     %%xmm1, %%xmm0          \n\t" \
+        "pavgb     %%xmm1, %%xmm0          \n\t" \
+        "movntdq   %%xmm0, (%%rsi,%%rdi)   \n\t" \
+        "add       $0x10, %%rsi            \n\t" \
+        "sub       $0x10, %%rcx            \n\t" \
+        "ja        2b                     \n\t" \
+        "23:                             \n\t" \
+        "add       $0x0f, %%rcx            \n\t" \
+        "pxor      %%xmm0, %%xmm0          \n\t" \
+        "movd      %%ecx, %%xmm0           \n\t" \
+        "pshufb    %%xmm0, %%xmm1          \n\t" \
+        "pminub    %[dq0toF], %%xmm1       \n\t" \
+        "pshufb    %%xmm1, %%xmm6          \n\t" \
+        "psrldq    $15, %%xmm7             \n\t" \
+        "pshufb    %%xmm0, %%xmm7          \n\t" \
+        "movdqa    %%xmm6, %%xmm0          \n\t" \
+        "movdqa    %%xmm7, %%xmm2          \n\t" \
+        "palignr	$10, %%xmm0, %%xmm5     \n\t" \
+        "palignr	$6, %%xmm2, %%xmm6      \n\t" \
+        "pavgb     %%xmm2, %%xmm0          \n\t" \
+        "movdqa    %%xmm6, %%xmm3          \n\t" \
+        "movdqa    %%xmm7, %%xmm4          \n\t" \
+        "palignr	$11, %%xmm3, %%xmm5     \n\t" \
+        "palignr	$5, %%xmm4, %%xmm6      \n\t" \
+        "pavgb     %%xmm4, %%xmm3          \n\t" \
+        "pavgb     %%xmm3, %%xmm0          \n\t" \
+        "movdqa    %%xmm6, %%xmm1          \n\t" \
+        "movdqa    %%xmm7, %%xmm2          \n\t" \
+        "palignr	$12, %%xmm1, %%xmm5     \n\t" \
+        "palignr	$4, %%xmm2, %%xmm6      \n\t" \
+        "pavgb     %%xmm2, %%xmm1          \n\t" \
+        "movdqa    %%xmm6, %%xmm3          \n\t" \
+        "movdqa    %%xmm7, %%xmm4          \n\t" \
+        "palignr	$13, %%xmm3, %%xmm5     \n\t" \
+        "palignr	$3, %%xmm4, %%xmm6      \n\t" \
+        "pavgb     %%xmm4, %%xmm3          \n\t" \
+        "pavgb     %%xmm3, %%xmm1          \n\t" \
+        "pavgb     %%xmm1, %%xmm0          \n\t" \
+        "movdqa    %%xmm6, %%xmm1          \n\t" \
+        "movdqa    %%xmm7, %%xmm2          \n\t" \
+        "palignr	$14, %%xmm1, %%xmm5     \n\t" \
+        "palignr	$2, %%xmm2, %%xmm6      \n\t" \
+        "pavgb     %%xmm2, %%xmm1          \n\t" \
+        "movdqa    %%xmm6, %%xmm3          \n\t" \
+        "movdqa    %%xmm7, %%xmm4          \n\t" \
+        "palignr	$15, %%xmm3, %%xmm5     \n\t" \
+        "palignr	$1, %%xmm4, %%xmm6      \n\t" \
+        "pavgb     %%xmm4, %%xmm3          \n\t" \
+        "pavgb     %%xmm3, %%xmm1          \n\t" \
+        "pavgb     %%xmm6, %%xmm1          \n\t" \
+        "movdqa    %%xmm6, %%xmm5          \n\t" \
+        "movdqa    %%xmm7, %%xmm6          \n\t" \
+        "pavgb     %%xmm1, %%xmm0          \n\t" \
+        "pavgb     %%xmm1, %%xmm0          \n\t" \
+        "movntdq   %%xmm0, (%%rsi,%%rdi)   \n\t" \
+    : \
+    : [psrc2] "r" (psrc2), [ptmp2] "r" (ptmp2), [i] "r" (i), [dq0toF] "m" (dq0toF) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
       psrc2 += src_pitch;
       ptmp2 += tmp_pitch;
     }
-  else if (g_cpuid & CPUF_SSE2)
+  else if (!(g_cpuid & CPUF_SSE2))
     // SSE2 version
     // 6 left and right pixels are wrong
     for (int y = 0; y < height; y++)
     {
-      __asm {
-        mov	QSI, psrc2
-        mov	QDI, ptmp2
-        movsx_int	QCX, ia
-        sub	QDI, QSI
-        align	10h
-        ls0 :
-        movdqu	xmm6, [QSI - 6]
-          movdqu	xmm0, [QSI + 6]
-          pavgb	xmm6, xmm0
-          movdqu	xmm5, [QSI - 5]
-          movdqu	xmm7, [QSI + 5]
-          pavgb	xmm5, xmm7
-          movdqu	xmm4, [QSI - 4]
-          movdqu	xmm0, [QSI + 4]
-          pavgb	xmm4, xmm0
-          movdqu	xmm3, [QSI - 3]
-          movdqu	xmm7, [QSI + 3]
-          pavgb	xmm3, xmm7
-          movdqu	xmm2, [QSI - 2]
-          movdqu	xmm0, [QSI + 2]
-          pavgb	xmm2, xmm0
-          movdqu	xmm1, [QSI - 1]
-          movdqu	xmm7, [QSI + 1]
-          pavgb	xmm1, xmm7
-          movdqa	xmm0, [QSI]
-          pavgb	xmm6, xmm5
-          pavgb	xmm4, xmm3
-          pavgb	xmm2, xmm1
-          pavgb	xmm6, xmm4
-          pavgb	xmm2, xmm0
-          pavgb	xmm6, xmm2
-          pavgb	xmm6, xmm2
-          movntdq[QSI + QDI], xmm6
-          add	QSI, 10h
-          dec	QCX
-          jnz	ls0
-      }
+      asm volatile ( \
+        "mov       %[psrc2], %%rsi         \n\t" \
+        "mov       %[ptmp2], %%rdi         \n\t" \
+        "movsxd    %[ia], %%rcx             \n\t" \
+        "sub       %%rsi, %%rdi            \n\t" \
+        ".align    0x10                    \n\t" \
+        "3:                             \n\t" \
+        "movdqu    -6(%%rsi), %%xmm6       \n\t" \
+        "movdqu    6(%%rsi), %%xmm0        \n\t" \
+        "pavgb     %%xmm0, %%xmm6          \n\t" \
+        "movdqu    -5(%%rsi), %%xmm5       \n\t" \
+        "movdqu    5(%%rsi), %%xmm7        \n\t" \
+        "pavgb     %%xmm7, %%xmm5          \n\t" \
+        "movdqu    -4(%%rsi), %%xmm4       \n\t" \
+        "movdqu    4(%%rsi), %%xmm0        \n\t" \
+        "pavgb     %%xmm0, %%xmm4          \n\t" \
+        "movdqu    -3(%%rsi), %%xmm3       \n\t" \
+        "movdqu    3(%%rsi), %%xmm7        \n\t" \
+        "pavgb     %%xmm7, %%xmm3          \n\t" \
+        "movdqu    -2(%%rsi), %%xmm2       \n\t" \
+        "movdqu    2(%%rsi), %%xmm0        \n\t" \
+        "pavgb     %%xmm0, %%xmm2          \n\t" \
+        "movdqu    -1(%%rsi), %%xmm1       \n\t" \
+        "movdqu    1(%%rsi), %%xmm7        \n\t" \
+        "pavgb     %%xmm7, %%xmm1          \n\t" \
+        "movdqa    (%%rsi), %%xmm0          \n\t" \
+        "pavgb     %%xmm5, %%xmm6          \n\t" \
+        "pavgb     %%xmm3, %%xmm4          \n\t" \
+        "pavgb     %%xmm1, %%xmm2          \n\t" \
+        "pavgb     %%xmm4, %%xmm6          \n\t" \
+        "pavgb     %%xmm0, %%xmm2          \n\t" \
+        "pavgb     %%xmm2, %%xmm6          \n\t" \
+        "pavgb     %%xmm2, %%xmm6          \n\t" \
+        "movntdq   %%xmm6, (%%rsi,%%rdi)   \n\t" \
+        "add       $0x10, %%rsi            \n\t" \
+        "dec       %%rcx                   \n\t" \
+        "jnz       3b                     \n\t" \
+    : \
+    : [psrc2] "r" (psrc2), [ptmp2] "r" (ptmp2), [ia] "r" (ia) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
       psrc2 += src_pitch;
       ptmp2 += tmp_pitch;
     }
-  __asm sfence;
+    asm volatile("sfence\n\t" : : : "memory", "cc");
 
   // Vertical Blur
   // WxH min: 1x12, mul: 1x1 (write 16x1)
-  if (g_cpuid & CPUF_SSE2)
+  if (!(g_cpuid & CPUF_SSE2))
   {
     // SSE2 version
     int y;
@@ -446,125 +446,131 @@ void BlurR6(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
     ptmp2 = ptmp;
     for (y = 0; y < 6; y++)
     {
-      __asm {
-        movsx_int	QAX, tmp_pitch
-        mov	QSI, ptmp2
-        mov	QDI, psrc2
-        movsx_int QCX, ia
-        lea	QBX, [QAX + QAX * 2] // pitch*3
-        lea	QDX, [QBX + QAX * 2] // pitch*5
-        add	QDX, QSI
-        sub	QDI, QSI
-        align	10h
-        l1 :
-        movdqa	xmm0, [QSI]
-          movdqa	xmm1, [QSI + QAX * 1]
-          movdqa	xmm2, [QSI + QAX * 2]
-          movdqa	xmm3, [QSI + QBX * 1] // pitch*3, fixed 20170928
-          movdqa	xmm4, [QSI + QAX * 4]
-          movdqa	xmm5, [QDX]           // pitch*5
-          movdqa	xmm6, [QDX + QAX * 1] // pitch*6
-          pavgb	xmm6, xmm5
-          pavgb	xmm4, xmm3
-          pavgb	xmm2, xmm1
-          pavgb	xmm6, xmm4
-          pavgb	xmm2, xmm0
-          pavgb	xmm6, xmm2
-          pavgb	xmm6, xmm2
-          movntdq[QSI + QDI], xmm6
-          add	QSI, 10h
-          add	QDX, 10h
-          dec	QCX
-          jnz	l1
-      }
+      asm volatile ( \
+        "movsxd     %[tmp_pitch], %%rax      \n\t" \
+        "mov        %[ptmp2], %%rsi         \n\t" \
+        "mov        %[psrc2], %%rdi         \n\t" \
+        "movsxd     %[ia], %%rcx             \n\t" \
+        "lea        (%%rax,%%rax,2), %%rbx   \n\t" \
+        "lea        (%%rbx,%%rax,2), %%rdx   \n\t" \
+        "add        %%rsi, %%rdx            \n\t" \
+        "sub        %%rsi, %%rdi            \n\t" \
+        ".align     0x10                    \n\t" \
+        "4:                                \n\t" \
+        "movdqa     (%%rsi), %%xmm0         \n\t" \
+        "movdqa     (%%rsi,%%rax,1), %%xmm1 \n\t" \
+        "movdqa     (%%rsi,%%rax,2), %%xmm2 \n\t" \
+        "movdqa     (%%rsi,%%rbx,1), %%xmm3 \n\t" \
+        "movdqa     (%%rsi,%%rax,4), %%xmm4 \n\t" \
+        "movdqa     (%%rdx), %%xmm5         \n\t" \
+        "movdqa     (%%rsi,%%rdx,1), %%xmm6 \n\t" \
+        "pavgb      %%xmm5, %%xmm6          \n\t" \
+        "pavgb      %%xmm3, %%xmm4          \n\t" \
+        "pavgb      %%xmm1, %%xmm2          \n\t" \
+        "pavgb      %%xmm4, %%xmm6          \n\t" \
+        "pavgb      %%xmm0, %%xmm2          \n\t" \
+        "pavgb      %%xmm2, %%xmm6          \n\t" \
+        "pavgb      %%xmm2, %%xmm6          \n\t" \
+        "movntdq    %%xmm6, (%%rsi,%%rdi)   \n\t" \
+        "add        $0x10, %%rsi            \n\t" \
+        "add        $0x10, %%rdx            \n\t" \
+        "dec        %%rcx                   \n\t" \
+        "jnz        4b                     \n\t" \
+    : \
+    : [tmp_pitch] "r" (tmp_pitch), [ptmp2] "r" (ptmp2), [psrc2] "r" (psrc2), [ia] "r" (ia) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
       psrc2 += src_pitch;
       ptmp2 += tmp_pitch;
     }
     ptmp2 = ptmp;
     for (; y < height - 6; y++)
     {
-      __asm {
-        movsx_int	QAX, tmp_pitch
-        mov	QSI, ptmp2
-        mov	QDI, psrc2
-        movsx_int	QCX, ia
-        push	QBP
-        lea	QBP, [QAX + QAX * 2]
-        lea	QDX, [QBP + QAX * 2]
-        lea	QBX, [QSI + QDX * 2]
-        add	QDX, QSI
-        sub	QDI, QSI
-        align	10h
-        l2 :
-        movdqa	xmm6, [QSI]
-          pavgb	xmm6, [QBX + QAX * 2]
-          movdqa	xmm5, [QSI + QAX * 1]
-          pavgb	xmm5, [QBX + QAX * 1]
-          movdqa	xmm4, [QSI + QAX * 2]
-          pavgb	xmm4, [QBX]
-          movdqa	xmm3, [QSI + QBP * 1]
-          pavgb	xmm3, [QDX + QAX * 4]
-          movdqa	xmm2, [QSI + QAX * 4]
-          pavgb	xmm2, [QSI + QAX * 8]
-          movdqa	xmm1, [QDX]
-          pavgb	xmm1, [QDX + QAX * 2]
-          movdqa	xmm0, [QDX + QAX * 1]
-          pavgb	xmm6, xmm5
-          pavgb	xmm4, xmm3
-          pavgb	xmm2, xmm1
-          pavgb	xmm6, xmm4
-          pavgb	xmm2, xmm0
-          pavgb	xmm6, xmm2
-          pavgb	xmm6, xmm2
-          movntdq[QSI + QDI], xmm6
-          add	QSI, 10h
-          add	QDX, 10h
-          add	QBX, 10h
-          dec	QCX
-          jnz	l2
-          pop	QBP
-      }
+      asm volatile ( \
+        "movsxd     %[tmp_pitch], %%rax      \n\t" \
+        "mov        %[ptmp2], %%rsi         \n\t" \
+        "mov        %[psrc2], %%rdi         \n\t" \
+        "movsxd     %[ia], %%rcx             \n\t" \
+        "push       %%rbp                   \n\t" \
+        "lea        (%%rax,%%rax,2), %%rbp   \n\t" \
+        "lea        (%%rbp,%%rax,2), %%rdx   \n\t" \
+        "lea        (%%rsi,%%rdx,2), %%rbx   \n\t" \
+        "add        %%rsi, %%rdx            \n\t" \
+        "sub        %%rsi, %%rdi            \n\t" \
+        ".align     0x10                    \n\t" \
+        "5:                              \n\t" \
+        "movdqa     (%%rsi), %%xmm6         \n\t" \
+        "pavgb      (%%rbx,%%rax,2), %%xmm6 \n\t" \
+        "movdqa     (%%rsi,%%rax,1), %%xmm5 \n\t" \
+        "pavgb      (%%rbx,%%rax,1), %%xmm5 \n\t" \
+        "movdqa     (%%rsi,%%rax,2), %%xmm4 \n\t" \
+        "pavgb      (%%rbx), %%xmm4          \n\t" \
+        "movdqa     (%%rsi,%%rbp,1), %%xmm3 \n\t" \
+        "pavgb      (%%rdx,%%rax,4), %%xmm3 \n\t" \
+        "movdqa     (%%rsi,%%rax,4), %%xmm2 \n\t" \
+        "pavgb      (%%rsi,%%rax,8), %%xmm2 \n\t" \
+        "movdqa     (%%rdx), %%xmm1         \n\t" \
+        "pavgb      (%%rdx,%%rax,2), %%xmm1 \n\t" \
+        "movdqa     (%%rdx,%%rax,1), %%xmm0 \n\t" \
+        "pavgb      %%xmm5, %%xmm6          \n\t" \
+        "pavgb      %%xmm3, %%xmm4          \n\t" \
+        "pavgb      %%xmm1, %%xmm2          \n\t" \
+        "pavgb      %%xmm4, %%xmm6          \n\t" \
+        "pavgb      %%xmm0, %%xmm2          \n\t" \
+        "pavgb      %%xmm2, %%xmm6          \n\t" \
+        "pavgb      %%xmm2, %%xmm6          \n\t" \
+        "movntdq    %%xmm6, (%%rsi,%%rdi)   \n\t" \
+        "add        $0x10, %%rsi            \n\t" \
+        "add        $0x10, %%rdx            \n\t" \
+        "add        $0x10, %%rbx            \n\t" \
+        "dec        %%rcx                   \n\t" \
+        "jnz        5b                      \n\t" \
+        "pop        %%rbp                   \n\t" \
+    : \
+    : [tmp_pitch] "r" (tmp_pitch), [ptmp2] "r" (ptmp2), [psrc2] "r" (psrc2), [ia] "r" (ia) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
       psrc2 += src_pitch;
       ptmp2 += tmp_pitch;
     }
     for (; y < height; y++)
     {
-      __asm {
-        movsx_int	QAX, tmp_pitch
-        mov	QSI, ptmp2
-        mov	QDI, psrc2
-        movsx_int	QCX, ia
-        lea	QBX, [QAX + QAX * 2] // pitch*3
-        lea	QDX, [QBX + QAX * 2] // pitch*5
-        add	QDX, QSI
-        sub	QDI, QSI
-        align	10h
-        l3 :
-        movdqa	xmm6, [QSI]
-          movdqa	xmm5, [QSI + QAX * 1]
-          movdqa	xmm4, [QSI + QAX * 2]
-          movdqa	xmm3, [QSI + QBX * 1] // pitch*3
-          movdqa	xmm2, [QSI + QAX * 4]
-          movdqa	xmm1, [QDX]           // pitch*5
-          movdqa	xmm0, [QDX + QAX * 1] // pitch*6
-          pavgb	xmm6, xmm5
-          pavgb	xmm4, xmm3
-          pavgb	xmm2, xmm1
-          pavgb	xmm6, xmm4
-          pavgb	xmm2, xmm0
-          pavgb	xmm6, xmm2
-          pavgb	xmm6, xmm2
-          movntdq[QSI + QDI], xmm6
-          add	QSI, 10h
-          add	QDX, 10h
-          dec	QCX
-          jnz	l3
-      }
+      asm volatile ( \
+        "movsxd     %[tmp_pitch], %%rax     \n\t" \
+        "mov        %[ptmp2], %%rsi         \n\t" \
+        "mov        %[psrc2], %%rdi         \n\t" \
+        "movsxd     %[ia], %%rcx            \n\t" \
+        "lea        (%%rax,%%rax,2), %%rbx  \n\t" \
+        "lea        (%%rbx,%%rax,2), %%rdx  \n\t" \
+        "add        %%rsi, %%rdx            \n\t" \
+        "sub        %%rsi, %%rdi            \n\t" \
+        ".align     0x10                    \n\t" \
+        "6:                                 \n\t" \
+        "movdqa     (%%rsi), %%xmm6         \n\t" \
+        "movdqa     (%%rsi,%%rax,1), %%xmm5 \n\t" \
+        "movdqa     (%%rsi,%%rax,2), %%xmm4 \n\t" \
+        "movdqa     (%%rsi,%%rbx,1), %%xmm3 \n\t" \
+        "movdqa     (%%rsi,%%rax,4), %%xmm2 \n\t" \
+        "movdqa     (%%rdx), %%xmm1         \n\t" \
+        "movdqa     (%%rdx,%%rax,1), %%xmm0 \n\t" \
+        "pavgb      %%xmm5, %%xmm6          \n\t" \
+        "pavgb      %%xmm3, %%xmm4          \n\t" \
+        "pavgb      %%xmm1, %%xmm2          \n\t" \
+        "pavgb      %%xmm4, %%xmm6          \n\t" \
+        "pavgb      %%xmm0, %%xmm2          \n\t" \
+        "pavgb      %%xmm2, %%xmm6          \n\t" \
+        "pavgb      %%xmm2, %%xmm6          \n\t" \
+        "movntdq    %%xmm6, (%%rsi,%%rdi)   \n\t" \
+        "add        $0x10, %%rsi            \n\t" \
+        "add        $0x10, %%rdx            \n\t" \
+        "dec        %%rcx                   \n\t" \
+        "jnz        6b                      \n\t" \
+    : \
+    : [tmp_pitch] "r" (tmp_pitch), [ptmp2] "r" (ptmp2), [psrc2] "r" (psrc2), [ia] "r" (ia) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
       psrc2 += src_pitch;
       ptmp2 += tmp_pitch;
     }
   }
-  __asm sfence;
+  asm volatile("sfence\n\t" : : : "memory", "cc");
 }
 
 // WxH min: 1x1, mul: 1x1 (write 16x1)
@@ -577,7 +583,7 @@ void BlurR2(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
   unsigned char *ptmp = tmp->GetWritePtr(plane);
   const int height = src->GetHeight() >> src_vi.GetPlaneHeightSubsampling(plane);
   const int i = src->GetRowSize() >> src_vi.GetPlaneWidthSubsampling(plane);
-  const int ia = i + 0xF & ~0xF;
+  const int ia = (i + 0xF) & ~0xF;
   unsigned char *psrc2, *ptmp2;
 
   psrc2 = psrc;
@@ -588,109 +594,113 @@ void BlurR2(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
     // SSSE3 version (palignr, pshufb)
     for (int y = 0; y < height; y++)
     {
-      __asm {
-        mov	QSI, psrc2
-        mov	QDI, ptmp2
-        movsx_int	QCX, i
-        add	QSI, 10h
-        sub	QDI, QSI
-        movdqa	xmm4, dq0toF
-        movdqa	xmm6, [QSI - 10h]
-        movdqa	xmm5, xmm6
-        movdqa	xmm7, xmm6
-        pxor	xmm0, xmm0
-        pshufb	xmm5, xmm0
-        sub	QCX, 10h
-        jna	l1e
-        align	10h
-        l1 :
-        movdqa	xmm7, [QSI]
-          movdqa	xmm0, xmm6
-          movdqa	xmm2, xmm7
-          palignr	xmm0, xmm5, 14
-          palignr	xmm2, xmm6, 2
-          pavgb	xmm0, xmm2
-          movdqa	xmm1, xmm6
-          movdqa	xmm3, xmm7
-          palignr	xmm1, xmm5, 15
-          palignr	xmm3, xmm6, 1
-          pavgb	xmm0, xmm6
-          pavgb	xmm1, xmm3
-          pavgb	xmm0, xmm6
-          movdqa	xmm5, xmm6
-          movdqa	xmm6, xmm7
-          pavgb	xmm0, xmm1
-          movntdq[QSI + QDI], xmm0
-          add	QSI, 10h
-          sub	QCX, 10h
-          ja	l1
-          l1e :
-        add	QCX, 0Fh
-          pxor	xmm0, xmm0
-          movd	xmm1, ecx
-          pshufb	xmm1, xmm0
-          pminub	xmm1, xmm4 // 0x0F0E..00
-          pshufb	xmm6, xmm1
-          psrldq	xmm7, 15
-          pshufb	xmm7, xmm0
-          movdqa	xmm0, xmm6
-          movdqa	xmm2, xmm7
-          palignr	xmm0, xmm5, 14
-          palignr	xmm2, xmm6, 2
-          pavgb	xmm0, xmm2
-          movdqa	xmm1, xmm6
-          movdqa	xmm3, xmm7
-          palignr	xmm1, xmm5, 15
-          palignr	xmm3, xmm6, 1
-          pavgb	xmm0, xmm6
-          pavgb	xmm1, xmm3
-          pavgb	xmm0, xmm6
-          movdqa	xmm5, xmm6
-          movdqa	xmm6, xmm7
-          pavgb	xmm0, xmm1
-          movntdq[QSI + QDI], xmm0
-      }
+      asm volatile ( \
+        "mov        %[psrc2], %%rsi         \n\t" \
+        "mov        %[ptmp2], %%rdi         \n\t" \
+        "movsxd     %[i], %%rcx             \n\t" \
+        "add        $0x10, %%rsi            \n\t" \
+        "sub        %%rsi, %%rdi            \n\t" \
+        "movdqa     %[dq0toF], %%xmm4       \n\t" \
+        "movdqa     -0x10(%%rsi), %%xmm6    \n\t" \
+        "movdqa     %%xmm6, %%xmm5          \n\t" \
+        "movdqa     %%xmm6, %%xmm7          \n\t" \
+        "pxor       %%xmm0, %%xmm0          \n\t" \
+        "pshufb     %%xmm0, %%xmm5          \n\t" \
+        "sub        $0x10, %%rcx            \n\t" \
+        "jna        24f                     \n\t" \
+        ".align     0x10                    \n\t" \
+        "7:                                 \n\t" \
+        "movdqa     (%%rsi), %%xmm7         \n\t" \
+        "movdqa     %%xmm6, %%xmm0          \n\t" \
+        "movdqa     %%xmm7, %%xmm2          \n\t" \
+        "palignr	$14, %%xmm0, %%xmm5     \n\t" \
+        "palignr	$2, %%xmm2, %%xmm6      \n\t" \
+        "pavgb      %%xmm2, %%xmm0          \n\t" \
+        "movdqa     %%xmm6, %%xmm1          \n\t" \
+        "movdqa     %%xmm7, %%xmm3          \n\t" \
+        "palignr	$15, %%xmm1, %%xmm5     \n\t" \
+        "palignr	$1, %%xmm3, %%xmm6      \n\t" \
+        "pavgb      %%xmm6, %%xmm0          \n\t" \
+        "pavgb      %%xmm3, %%xmm1          \n\t" \
+        "pavgb      %%xmm6, %%xmm0          \n\t" \
+        "movdqa     %%xmm6, %%xmm5          \n\t" \
+        "movdqa     %%xmm7, %%xmm6          \n\t" \
+        "pavgb      %%xmm1, %%xmm0          \n\t" \
+        "movntdq    %%xmm0, (%%rsi,%%rdi)   \n\t" \
+        "add        $0x10, %%rsi            \n\t" \
+        "sub        $0x10, %%rcx            \n\t" \
+        "ja         7b                      \n\t" \
+        "24:                                \n\t" \
+        "add        $0x0f, %%rcx            \n\t" \
+        "pxor       %%xmm0, %%xmm0          \n\t" \
+        "movd       %%ecx, %%xmm1           \n\t" \
+        "pshufb     %%xmm0, %%xmm1          \n\t" \
+        "pminub     %%xmm4, %%xmm1          \n\t" \
+        "pshufb     %%xmm1, %%xmm6          \n\t" \
+        "psrldq     $15, %%xmm7             \n\t" \
+        "pshufb     %%xmm0, %%xmm7          \n\t" \
+        "movdqa     %%xmm6, %%xmm0          \n\t" \
+        "movdqa     %%xmm7, %%xmm2          \n\t" \
+        "palignr	$14, %%xmm0, %%xmm5     \n\t" \
+        "palignr	$2, %%xmm2, %%xmm6      \n\t" \
+        "pavgb      %%xmm2, %%xmm0          \n\t" \
+        "movdqa     %%xmm6, %%xmm1          \n\t" \
+        "movdqa     %%xmm7, %%xmm3          \n\t" \
+        "palignr	$15, %%xmm1, %%xmm5     \n\t" \
+        "palignr	$1, %%xmm3, %%xmm6      \n\t" \
+        "pavgb      %%xmm6, %%xmm0          \n\t" \
+        "pavgb      %%xmm3, %%xmm1          \n\t" \
+        "pavgb      %%xmm6, %%xmm0          \n\t" \
+        "movdqa     %%xmm6, %%xmm5          \n\t" \
+        "movdqa     %%xmm7, %%xmm6          \n\t" \
+        "pavgb      %%xmm1, %%xmm0          \n\t" \
+        "movntdq    %%xmm0, (%%rsi,%%rdi)   \n\t" \
+    : \
+    : [ptmp2] "r" (ptmp2), [psrc2] "r" (psrc2), [i] "r" (i), [dq0toF] "m" (dq0toF) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
       psrc2 += src_pitch;
       ptmp2 += tmp_pitch;
     }
-  else if (g_cpuid & CPUF_SSE2)
+  else if (!(g_cpuid & CPUF_SSE2))
     // SSE2 version
     // 2 left and right pixels are wrong
     for (int y = 0; y < height; y++)
     {
-      __asm {
-        mov	QSI, psrc2
-        mov	QDI, ptmp2
-        movsx_int	QCX, ia
-        add	QSI, QCX
-        add	QDI, QCX
-        neg	QCX
-        align	10h
-        ls1 :
-        movdqu	xmm0, [QCX + QSI - 2]
-          movdqu	xmm4, [QCX + QSI + 2]
-          pavgb	xmm0, xmm4
-          movdqu	xmm1, [QCX + QSI - 1]
-          movdqu	xmm3, [QCX + QSI + 1]
-          pavgb	xmm1, xmm3
-          movdqa	xmm2, [QCX + QSI]
-          pavgb	xmm0, xmm2
-          pavgb	xmm0, xmm2
-          pavgb	xmm0, xmm1
-          movntdq[QCX + QDI], xmm0
-          add	QCX, 10h
-          jnz	ls1
-      }
+      asm volatile ( \
+        "mov        %[psrc2], %%rsi         \n\t" \
+        "mov        %[ptmp2], %%rdi         \n\t" \
+        "movsxd     %[ia], %%rcx            \n\t" \
+        "add        %%rcx, %%rsi            \n\t" \
+        "add        %%rcx, %%rdi            \n\t" \
+        "neg        %%rcx                   \n\t" \
+        ".align     0x10                    \n\t" \
+        "8:                                 \n\t" \
+        "movdqu     -2(%%rcx,%%rsi), %%xmm0 \n\t" \
+        "movdqu     2(%%rcx,%%rsi), %%xmm4  \n\t" \
+        "pavgb      %%xmm4, %%xmm0          \n\t" \
+        "movdqu     -1(%%rcx,%%rsi), %%xmm1 \n\t" \
+        "movdqu     1(%%rcx,%%rsi), %%xmm3  \n\t" \
+        "pavgb      %%xmm3, %%xmm1          \n\t" \
+        "movdqa     (%%rcx,%%rsi), %%xmm2   \n\t" \
+        "pavgb      %%xmm2, %%xmm0          \n\t" \
+        "pavgb      %%xmm2, %%xmm0          \n\t" \
+        "pavgb      %%xmm1, %%xmm0          \n\t" \
+        "movntdq    %%xmm0, (%%rcx,%%rdi)   \n\t" \
+        "add        $0x10, %%rcx            \n\t" \
+        "jnz        8b                      \n\t" \
+    : \
+    : [ptmp2] "r" (ptmp2), [psrc2] "r" (psrc2), [ia] "r" (ia) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
       psrc2 += src_pitch;
       ptmp2 += tmp_pitch;
     }
-  __asm sfence;
+  asm volatile("sfence\n\t" : : : "memory", "cc");
 
   psrc2 = psrc;
   ptmp2 = ptmp;
   // Vertical Blur
   // WxH min: 1x1, mul: 1x1 (write 16x1)
-  if (g_cpuid & CPUF_SSE2)
+  if (!(g_cpuid & CPUF_SSE2))
     // SSE2 version
     for (int y = 0; y < height; y++)
     {
@@ -698,36 +708,38 @@ void BlurR2(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
       int tmp_pitchp2 = y > 1 ? tmp_pitchp1 * 2 : tmp_pitchp1;
       int tmp_pitchn1 = y < height - 1 ? tmp_pitch : 0;
       int tmp_pitchn2 = y < height - 2 ? tmp_pitchn1 * 2 : tmp_pitchn1;
-      __asm {
-        push	QBP
-        mov	QSI, ptmp2
-        mov	QDI, psrc2
-        movsx_int	QCX, ia
-        movsx_int	QAX, tmp_pitchp2
-        movsx_int	QDX, tmp_pitchn2
-        movsx_int	QBX, tmp_pitchp1
-        movsx_int	QBP, tmp_pitchn1
-        sub	QDI, QSI
-        align	10h
-        l2 :
-        movdqa	xmm0, [QSI + QAX]
-          pavgb	xmm0, [QSI + QDX]
-          movdqa	xmm1, [QSI + QBX]
-          pavgb	xmm1, [QSI + QBP]
-          movdqa	xmm2, [QSI]
-          pavgb	xmm0, xmm2
-          pavgb	xmm0, xmm2
-          pavgb	xmm0, xmm1
-          movntdq[QSI + QDI], xmm0
-          add	QSI, 10h
-          sub	QCX, 10h
-          jnz	l2
-          pop	QBP
-      }
+      asm volatile ( \
+        "push       %%rbp                   \n\t" \
+        "mov        %[ptmp2], %%rsi         \n\t" \
+        "mov        %[psrc2], %%rdi         \n\t" \
+        "movsxd     %[ia], %%rcx            \n\t" \
+        "movsxd     %[tmp_pitchp2], %%rax   \n\t" \
+        "movsxd     %[tmp_pitchn2], %%rdx   \n\t" \
+        "movsxd     %[tmp_pitchp1], %%rbx   \n\t" \
+        "movsxd     %[tmp_pitchn1], %%rbp   \n\t" \
+        "sub        %%rsi, %%rdi            \n\t" \
+        ".align     0x10                    \n\t" \
+        "9:                                 \n\t" \
+        "movdqa     (%%rsi,%%rax), %%xmm0   \n\t" \
+        "pavgb      (%%rsi,%%rdx), %%xmm0   \n\t" \
+        "movdqa     (%%rsi,%%rbx), %%xmm1   \n\t" \
+        "pavgb      (%%rsi,%%rbp), %%xmm1   \n\t" \
+        "movdqa     (%%rsi), %%xmm2         \n\t" \
+        "pavgb      %%xmm2, %%xmm0          \n\t" \
+        "pavgb      %%xmm2, %%xmm0          \n\t" \
+        "pavgb      %%xmm1, %%xmm0          \n\t" \
+        "movntdq    %%xmm0, (%%rsi,%%rdi)   \n\t" \
+        "add        $0x10, %%rsi            \n\t" \
+        "sub        $0x10, %%rcx            \n\t" \
+        "jnz        9b                      \n\t" \
+        "pop        %%rbp                   \n\t" \
+    : \
+    : [ptmp2] "r" (ptmp2), [psrc2] "r" (psrc2), [ia] "r" (ia), [tmp_pitchp2] "r" (tmp_pitchp2), [tmp_pitchn2] "r" (tmp_pitchn2), [tmp_pitchp1] "r" (tmp_pitchp1), [tmp_pitchn1] "r" (tmp_pitchn1) \
+    : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
       psrc2 += src_pitch;
       ptmp2 += tmp_pitch;
     }
-  __asm sfence;
+  asm volatile("sfence\n\t" : : : "memory", "cc");
 }
 
 void GuideChroma(PVideoFrame &src, PVideoFrame &dst, const VideoInfo &src_vi, const VideoInfo &dst_vi, bool cplace_mpeg2_flag)
@@ -766,57 +778,59 @@ void GuideChroma(PVideoFrame &src, PVideoFrame &dst, const VideoInfo &src_vi, co
     // MPEG-1
     else
     {
-      if (g_cpuid & CPUF_SSE2)
+      if (!(g_cpuid & CPUF_SSE2))
       {
         // SSE2 version
         for (int y = 0; y < height; y++)
         {
-          __asm {
-            movsx_int	QCX, i
-            mov	QSI, py
-            movsx_int	QAX, pitch_y
-            mov	QDX, pu
-            sub	QSI, QCX
-            sub	QSI, QCX
-            add	QAX, QSI
-            sub	QDX, QCX
-            sub	QDX, 10h
-            pcmpeqw	xmm7, xmm7
-            psrlw	xmm7, 8
-            align	10h
-            l :
-            movdqa	xmm0, [QSI + QCX * 2]
-              movdqa	xmm2, [QSI + QCX * 2 + 10h]
-              movdqa	xmm1, xmm0
-              movdqa	xmm3, xmm2
-              pand	xmm0, xmm7
-              pand	xmm2, xmm7
-              packuswb	xmm0, xmm2
-              psrlw	xmm1, 8
-              psrlw	xmm3, 8
-              packuswb	xmm1, xmm3
-              pavgb	xmm0, xmm1
-              movdqa	xmm1, [QAX + QCX * 2]
-              movdqa	xmm3, [QAX + QCX * 2 + 10h]
-              movdqa	xmm2, xmm1
-              movdqa	xmm4, xmm3
-              pand	xmm1, xmm7
-              pand	xmm3, xmm7
-              packuswb	xmm1, xmm3
-              psrlw	xmm2, 8
-              psrlw	xmm4, 8
-              packuswb	xmm2, xmm4
-              pavgb	xmm1, xmm2
-              pavgb	xmm0, xmm1
-              add	QCX, 10h
-              jg	ls
-              movntdq[QCX + QDX], xmm0
-              jnz	l
-              jmp	lx
-              ls :
-            movq	qword ptr[QCX + QDX], xmm0
-              lx :
-          }
+          asm volatile ( \
+            "movsxd     %[i], %%rcx             \n\t" \
+            "mov        %[py], %%rsi            \n\t" \
+            "movsxd     %[pitch_y], %%rax       \n\t" \
+            "mov        %[pu], %%rdx            \n\t" \
+            "sub        %%rcx, %%rsi            \n\t" \
+            "sub        %%rcx, %%rsi            \n\t" \
+            "add        %%rsi, %%rax            \n\t" \
+            "sub        %%rcx, %%rdx            \n\t" \
+            "sub        $0x10, %%rdx            \n\t" \
+            "pcmpeqw    %%xmm7, %%xmm7          \n\t" \
+            "psrlw      $8, %%xmm7              \n\t" \
+            ".align     0x10                    \n\t" \
+            "10:                                \n\t" \
+            "movdqa     (%%rsi,%%rcx,2), %%xmm0 \n\t" \
+            "movdqa     0x10(%%rsi,%%rcx,2), %%xmm2 \n\t" \
+            "movdqa     %%xmm0, %%xmm1          \n\t" \
+            "movdqa     %%xmm2, %%xmm3          \n\t" \
+            "pand       %%xmm7, %%xmm0          \n\t" \
+            "pand       %%xmm7, %%xmm2          \n\t" \
+            "packuswb   %%xmm2, %%xmm0          \n\t" \
+            "psrlw      $8, %%xmm1              \n\t" \
+            "psrlw      $8, %%xmm3              \n\t" \
+            "packuswb   %%xmm3, %%xmm1          \n\t" \
+            "pavgb      %%xmm1, %%xmm0          \n\t" \
+            "movdqa     (%%rax,%%rcx,2), %%xmm1 \n\t" \
+            "movdqa     0x10(%%rax,%%rcx,2), %%xmm3 \n\t" \
+            "movdqa     %%xmm1, %%xmm2          \n\t" \
+            "movdqa     %%xmm3, %%xmm4          \n\t" \
+            "pand       %%xmm7, %%xmm1          \n\t" \
+            "pand       %%xmm7, %%xmm3          \n\t" \
+            "packuswb   %%xmm3, %%xmm1          \n\t" \
+            "psrlw      $8, %%xmm2              \n\t" \
+            "psrlw      $8, %%xmm4              \n\t" \
+            "packuswb   %%xmm4, %%xmm2          \n\t" \
+            "pavgb      %%xmm2, %%xmm1          \n\t" \
+            "pavgb      %%xmm1, %%xmm0          \n\t" \
+            "add        $0x10, %%rcx            \n\t" \
+            "jg         25f                     \n\t" \
+            "movntdq    %%xmm0, (%%rcx,%%rdx)   \n\t" \
+            "jnz        10b                     \n\t" \
+            "jmp        26f                     \n\t" \
+            "25:                                \n\t" \
+            "movq       %%xmm0, (%%rcx,%%rdx)   \n\t" \
+            "26:                                \n\t" \
+          : \
+          : [i] "r" (i), [py] "r" (py), [pitch_y] "r" (pitch_y), [pu] "r" (pu) \
+          : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
           py += pitch_y * 2;
           pu += pitch_uv;
         }
@@ -848,44 +862,46 @@ void GuideChroma(PVideoFrame &src, PVideoFrame &dst, const VideoInfo &src_vi, co
     // MPEG-1
     else
     {
-      if (g_cpuid & CPUF_SSE2)
+      if (!(g_cpuid & CPUF_SSE2))
       {
         // SSE2 version
         for (int y = 0; y < height; y++)
         {
-          __asm {
-            movsx_int	QCX, i 
-            mov	QSI, py
-            movsx_int	QAX, pitch_y 
-            mov	QDX, pu
-            sub	QSI, QCX
-            sub	QSI, QCX
-            sub	QDX, QCX
-            sub	QDX, 10h
-            pcmpeqw	xmm7, xmm7
-            psrlw	xmm7, 8
-            align	10h
-            l422 :
-            movdqa	xmm0, [QSI + QCX * 2]
-              movdqa	xmm2, [QSI + QCX * 2 + 10h]
-              movdqa	xmm1, xmm0
-              movdqa	xmm3, xmm2
-              pand	xmm0, xmm7
-              pand	xmm2, xmm7
-              packuswb	xmm0, xmm2
-              psrlw	xmm1, 8
-              psrlw	xmm3, 8
-              packuswb	xmm1, xmm3
-              pavgb	xmm0, xmm1
-              add	QCX, 10h
-              jg	ls422
-              movntdq[QCX + QDX], xmm0
-              jnz	l422
-              jmp	lx422
-              ls422 :
-            movq	qword ptr[QCX + QDX], xmm0
-              lx422 :
-          }
+          asm volatile ( \
+            "movsxd     %[i], %%rcx             \n\t" \
+            "mov        %[py], %%rsi            \n\t" \
+            "movsxd     %[pitch_y], %%rax       \n\t" \
+            "mov        %[pu], %%rdx            \n\t" \
+            "sub        %%rcx, %%rsi            \n\t" \
+            "sub        %%rcx, %%rsi            \n\t" \
+            "sub        %%rcx, %%rdx            \n\t" \
+            "sub        $0x10, %%rdx            \n\t" \
+            "pcmpeqw    %%xmm7, %%xmm7          \n\t" \
+            "psrlw      $8, %%xmm7              \n\t" \
+            ".align     0x10                    \n\t" \
+            "11:                                \n\t" \
+            "movdqa     (%%rsi,%%rcx,2), %%xmm0 \n\t" \
+            "movdqa     0x10(%%rsi,%%rcx,2), %%xmm2 \n\t" \
+            "movdqa     %%xmm0, %%xmm1          \n\t" \
+            "movdqa     %%xmm2, %%xmm3          \n\t" \
+            "pand       %%xmm7, %%xmm0          \n\t" \
+            "pand       %%xmm7, %%xmm2          \n\t" \
+            "packuswb   %%xmm2, %%xmm0          \n\t" \
+            "psrlw      $8, %%xmm1              \n\t" \
+            "psrlw      $8, %%xmm3              \n\t" \
+            "packuswb   %%xmm3, %%xmm1          \n\t" \
+            "pavgb      %%xmm1, %%xmm0          \n\t" \
+            "add        $0x10, %%rcx            \n\t" \
+            "jg         27f                     \n\t" \
+            "movntdq    %%xmm0, (%%rcx,%%rdx)   \n\t" \
+            "jnz        11b                     \n\t" \
+            "jmp        28f                     \n\t" \
+            "27:                                \n\t" \
+            "movq       %%xmm0, (%%rcx,%%rdx)   \n\t" \
+            "28:                                \n\t" \
+          : \
+          : [i] "r" (i), [py] "r" (py), [pitch_y] "r" (pitch_y), [pu] "r" (pu) \
+          : "memory", "cc", "%rsi", "%rdi", "%rax", "%rbp", "%rbx", "%rcx", "%rdx", "%ecx", "%xmm0", "%xmm1", "%xmm2", "%xmm3", "%xmm4", "%xmm5", "%xmm6", "%xmm7" );
           py += pitch_y;
           pu += pitch_uv;
         }
@@ -907,7 +923,7 @@ void GuideChroma(PVideoFrame &src, PVideoFrame &dst, const VideoInfo &src_vi, co
     assert(false);
     throw "aWarpSharp2: Unsupported colorspace.";
   }
-  __asm sfence;
+  asm volatile("sfence\n\t" : : : "memory", "cc");
 }
 
 #pragma optimize("", on)
@@ -970,8 +986,8 @@ void CopyPlane(PVideoFrame &src, PVideoFrame &dst, int plane, const VideoInfo &d
 
 void CheckParams(IScriptEnvironment *env, const char *name, bool yuvPlanar, int thresh, int blur_type, int depth, int depthC, int chroma)
 {
-  if (!(g_cpuid & CPUF_SSE2))
-    env->ThrowError("%s: SSE2 capable CPU is required", name);
+  //if (!(g_cpuid & CPUF_SSE2))
+    //env->ThrowError("%s: SSE2 capable CPU is required", name);
   if (!yuvPlanar)
     env->ThrowError("%s: Planar YUV input is required", name);
   if (thresh < 0 || thresh > 255)
@@ -1084,8 +1100,8 @@ PVideoFrame __stdcall aWarpSharp::GetFrame(int n, IScriptEnvironment *env)
     }
   }
 
-  if (!(g_cpuid & CPUF_SSE2))
-    __asm emms;
+  //if (!(g_cpuid & CPUF_SSE2))
+    //asm volatile("emms\n\t" : : : "memory", "cc");
 
   return dst;
 }
@@ -1153,8 +1169,8 @@ PVideoFrame __stdcall aSobel::GetFrame(int n, IScriptEnvironment *env)
     break;
   }
 
-  if (!(g_cpuid & CPUF_SSE2))
-    __asm emms;
+  //if (!(g_cpuid & CPUF_SSE2))
+    //asm volatile("emms\n\t" : : : "memory", "cc");
 
   return dst;
 }
@@ -1219,8 +1235,8 @@ PVideoFrame __stdcall aBlur::GetFrame(int n, IScriptEnvironment *env)
     break;
   }
 
-  if (!(g_cpuid & CPUF_SSE2))
-    __asm emms;
+  //if (!(g_cpuid & CPUF_SSE2))
+    //asm volatile("emms\n\t" : : : "memory", "cc");
 
   return src;
 }
@@ -1243,7 +1259,7 @@ public:
     bits_per_pixel = vi.BitsPerComponent();
 
     const VideoInfo &vi2 = edges->GetVideoInfo();
-    if (depthC == NULL)
+    if (depthC == 0)
       depthC = vi.Is444() ? depth : depth / 2;
     if (vi.IsY())
       chroma = 1;
@@ -1319,8 +1335,8 @@ PVideoFrame __stdcall aWarp::GetFrame(int n, IScriptEnvironment *env)
     break;
   }
 
-  if (!(g_cpuid & CPUF_SSE2))
-    __asm emms;
+  //if (!(g_cpuid & CPUF_SSE2))
+    //asm volatile("emms\n\t" : : : "memory", "cc");
 
   return dst;
 }
@@ -1343,7 +1359,7 @@ public:
     bits_per_pixel = vi.BitsPerComponent();
 
     const VideoInfo &vi2 = edges->GetVideoInfo();
-    if (depthC == NULL)
+    if (depthC == 0)
       depthC = vi.Is444() ? depth : depth / 2;
     if (vi.IsY())
       chroma = 1;
@@ -1420,8 +1436,8 @@ PVideoFrame __stdcall aWarp4::GetFrame(int n, IScriptEnvironment *env)
     break;
   }
 
-  if (!(g_cpuid & CPUF_SSE2))
-    __asm emms;
+  //if (!(g_cpuid & CPUF_SSE2))
+    //asm volatile("emms\n\t" : : : "memory", "cc");
 
   return dst;
 }
@@ -1438,7 +1454,7 @@ AVSValue __cdecl Create_aWarpSharp(AVSValue args, void *user_data, IScriptEnviro
   switch ((intptr_t)user_data)
   {
   case 0:
-    return new aWarpSharp(args[0].AsClip(), args[1].AsInt(0x80), args[2].AsInt(args[3].AsInt(0) ? 3 : 2), args[3].AsInt(0), args[4].AsInt(16), args[5].AsInt(4), args[6].AsInt(NULL), is_cplace_mpeg2(args, 7), env);
+    return new aWarpSharp(args[0].AsClip(), args[1].AsInt(0x80), args[2].AsInt(args[3].AsInt(0) ? 3 : 2), args[3].AsInt(0), args[4].AsInt(16), args[5].AsInt(4), args[6].AsInt(0), is_cplace_mpeg2(args, 7), env);
   case 1:
   {
     const int type = args[5].AsInt(2) != 2;
@@ -1452,11 +1468,11 @@ AVSValue __cdecl Create_aWarpSharp(AVSValue args, void *user_data, IScriptEnviro
   case 3:
     return new aBlur(args[0].AsClip(), args[1].AsInt(args[2].AsInt(1) ? 3 : 2), args[2].AsInt(1), args[3].AsInt(1), env);
   case 4:
-    return new aWarp(args[0].AsClip(), args[1].AsClip(), args[2].AsInt(3), args[3].AsInt(4), args[4].AsInt(NULL), is_cplace_mpeg2(args, 5), env);
+    return new aWarp(args[0].AsClip(), args[1].AsClip(), args[2].AsInt(3), args[3].AsInt(4), args[4].AsInt(0), is_cplace_mpeg2(args, 5), env);
   case 5:
-    return new aWarp4(args[0].AsClip(), args[1].AsClip(), args[2].AsInt(3), args[3].AsInt(4), args[4].AsInt(NULL), is_cplace_mpeg2(args, 5), env);
+    return new aWarp4(args[0].AsClip(), args[1].AsClip(), args[2].AsInt(3), args[3].AsInt(4), args[4].AsInt(0), is_cplace_mpeg2(args, 5), env);
   }
-  return NULL;
+  return 0;
 }
 
 // thresh: 0..255

--- a/src/aWarpSharp.cpp
+++ b/src/aWarpSharp.cpp
@@ -290,36 +290,36 @@ void BlurR6(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
         "movdqa    (%%rsi), %%xmm7           \n\t" \
         "movdqa    %%xmm6, %%xmm0          \n\t" \
         "movdqa    %%xmm7, %%xmm2          \n\t" \
-        "palignr	$10, %%xmm0, %%xmm5     \n\t" \
-        "palignr	$6, %%xmm2, %%xmm6      \n\t" \
+        "palignr	$10, %%xmm5, %%xmm0     \n\t" \
+        "palignr	$6, %%xmm6, %%xmm2      \n\t" \
         "pavgb     %%xmm2, %%xmm0          \n\t" \
         "movdqa    %%xmm6, %%xmm3          \n\t" \
         "movdqa    %%xmm7, %%xmm4          \n\t" \
-        "palignr	$11, %%xmm3, %%xmm5     \n\t" \
-        "palignr	$5, %%xmm4, %%xmm6      \n\t" \
+        "palignr	$11, %%xmm5, %%xmm3     \n\t" \
+        "palignr	$5, %%xmm6, %%xmm4      \n\t" \
         "pavgb     %%xmm4, %%xmm3          \n\t" \
         "pavgb     %%xmm3, %%xmm0          \n\t" \
         "movdqa    %%xmm6, %%xmm1          \n\t" \
         "movdqa    %%xmm7, %%xmm2          \n\t" \
-        "palignr	$12, %%xmm1, %%xmm5     \n\t" \
-        "palignr	$4, %%xmm2, %%xmm6      \n\t" \
+        "palignr	$12, %%xmm5, %%xmm1     \n\t" \
+        "palignr	$4, %%xmm6, %%xmm2      \n\t" \
         "pavgb     %%xmm2, %%xmm1          \n\t" \
         "movdqa    %%xmm6, %%xmm3          \n\t" \
         "movdqa    %%xmm7, %%xmm4          \n\t" \
-        "palignr	$13, %%xmm3, %%xmm5     \n\t" \
-        "palignr	$3, %%xmm4, %%xmm6      \n\t" \
+        "palignr	$13, %%xmm5, %%xmm3     \n\t" \
+        "palignr	$3, %%xmm6, %%xmm4      \n\t" \
         "pavgb     %%xmm4, %%xmm3          \n\t" \
         "pavgb     %%xmm3, %%xmm1          \n\t" \
         "pavgb     %%xmm1, %%xmm0          \n\t" \
         "movdqa    %%xmm6, %%xmm1          \n\t" \
         "movdqa    %%xmm7, %%xmm2          \n\t" \
-        "palignr	$14, %%xmm1, %%xmm5     \n\t" \
-        "palignr	$2, %%xmm2, %%xmm6      \n\t" \
+        "palignr	$14, %%xmm5, %%xmm1     \n\t" \
+        "palignr	$2, %%xmm6, %%xmm2      \n\t" \
         "pavgb     %%xmm2, %%xmm1          \n\t" \
         "movdqa    %%xmm6, %%xmm3          \n\t" \
         "movdqa    %%xmm7, %%xmm4          \n\t" \
-        "palignr	$15, %%xmm3, %%xmm5     \n\t" \
-        "palignr	$1, %%xmm4, %%xmm6      \n\t" \
+        "palignr	$15, %%xmm5, %%xmm3     \n\t" \
+        "palignr	$1, %%xmm6, %%xmm4     \n\t" \
         "pavgb     %%xmm4, %%xmm3          \n\t" \
         "pavgb     %%xmm3, %%xmm1          \n\t" \
         "pavgb     %%xmm6, %%xmm1          \n\t" \
@@ -342,36 +342,36 @@ void BlurR6(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
         "pshufb    %%xmm0, %%xmm7          \n\t" \
         "movdqa    %%xmm6, %%xmm0          \n\t" \
         "movdqa    %%xmm7, %%xmm2          \n\t" \
-        "palignr	$10, %%xmm0, %%xmm5     \n\t" \
-        "palignr	$6, %%xmm2, %%xmm6      \n\t" \
+        "palignr	$10, %%xmm5, %%xmm0     \n\t" \
+        "palignr	$6, %%xmm6, %%xmm2     \n\t" \
         "pavgb     %%xmm2, %%xmm0          \n\t" \
         "movdqa    %%xmm6, %%xmm3          \n\t" \
         "movdqa    %%xmm7, %%xmm4          \n\t" \
-        "palignr	$11, %%xmm3, %%xmm5     \n\t" \
-        "palignr	$5, %%xmm4, %%xmm6      \n\t" \
+        "palignr	$11, %%xmm5, %%xmm3     \n\t" \
+        "palignr	$5, %%xmm6, %%xmm4     \n\t" \
         "pavgb     %%xmm4, %%xmm3          \n\t" \
         "pavgb     %%xmm3, %%xmm0          \n\t" \
         "movdqa    %%xmm6, %%xmm1          \n\t" \
         "movdqa    %%xmm7, %%xmm2          \n\t" \
-        "palignr	$12, %%xmm1, %%xmm5     \n\t" \
-        "palignr	$4, %%xmm2, %%xmm6      \n\t" \
+        "palignr	$12, %%xmm5, %%xmm1    \n\t" \
+        "palignr	$4, %%xmm6, %%xmm2      \n\t" \
         "pavgb     %%xmm2, %%xmm1          \n\t" \
         "movdqa    %%xmm6, %%xmm3          \n\t" \
         "movdqa    %%xmm7, %%xmm4          \n\t" \
-        "palignr	$13, %%xmm3, %%xmm5     \n\t" \
-        "palignr	$3, %%xmm4, %%xmm6      \n\t" \
+        "palignr	$13, %%xmm5, %%xmm3     \n\t" \
+        "palignr	$3, %%xmm6, %%xmm4      \n\t" \
         "pavgb     %%xmm4, %%xmm3          \n\t" \
         "pavgb     %%xmm3, %%xmm1          \n\t" \
         "pavgb     %%xmm1, %%xmm0          \n\t" \
         "movdqa    %%xmm6, %%xmm1          \n\t" \
         "movdqa    %%xmm7, %%xmm2          \n\t" \
-        "palignr	$14, %%xmm1, %%xmm5     \n\t" \
-        "palignr	$2, %%xmm2, %%xmm6      \n\t" \
+        "palignr	$14, %%xmm5, %%xmm1     \n\t" \
+        "palignr	$2, %%xmm6, %%xmm2      \n\t" \
         "pavgb     %%xmm2, %%xmm1          \n\t" \
         "movdqa    %%xmm6, %%xmm3          \n\t" \
         "movdqa    %%xmm7, %%xmm4          \n\t" \
-        "palignr	$15, %%xmm3, %%xmm5     \n\t" \
-        "palignr	$1, %%xmm4, %%xmm6      \n\t" \
+        "palignr	$15, %%xmm5, %%xmm3     \n\t" \
+        "palignr	$1, %%xmm6, %%xmm4      \n\t" \
         "pavgb     %%xmm4, %%xmm3          \n\t" \
         "pavgb     %%xmm3, %%xmm1          \n\t" \
         "pavgb     %%xmm6, %%xmm1          \n\t" \
@@ -613,13 +613,13 @@ void BlurR2(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
         "movdqa     (%%rsi), %%xmm7         \n\t" \
         "movdqa     %%xmm6, %%xmm0          \n\t" \
         "movdqa     %%xmm7, %%xmm2          \n\t" \
-        "palignr	$14, %%xmm0, %%xmm5     \n\t" \
-        "palignr	$2, %%xmm2, %%xmm6      \n\t" \
+        "palignr	$14, %%xmm5, %%xmm0     \n\t" \
+        "palignr	$2, %%xmm6, %%xmm2      \n\t" \
         "pavgb      %%xmm2, %%xmm0          \n\t" \
         "movdqa     %%xmm6, %%xmm1          \n\t" \
         "movdqa     %%xmm7, %%xmm3          \n\t" \
-        "palignr	$15, %%xmm1, %%xmm5     \n\t" \
-        "palignr	$1, %%xmm3, %%xmm6      \n\t" \
+        "palignr	$15, %%xmm5, %%xmm1     \n\t" \
+        "palignr	$1, %%xmm6, %%xmm3      \n\t" \
         "pavgb      %%xmm6, %%xmm0          \n\t" \
         "pavgb      %%xmm3, %%xmm1          \n\t" \
         "pavgb      %%xmm6, %%xmm0          \n\t" \
@@ -641,13 +641,13 @@ void BlurR2(PVideoFrame &src, PVideoFrame &tmp, int plane, const VideoInfo &src_
         "pshufb     %%xmm0, %%xmm7          \n\t" \
         "movdqa     %%xmm6, %%xmm0          \n\t" \
         "movdqa     %%xmm7, %%xmm2          \n\t" \
-        "palignr	$14, %%xmm0, %%xmm5     \n\t" \
-        "palignr	$2, %%xmm2, %%xmm6      \n\t" \
+        "palignr	$14, %%xmm5, %%xmm0     \n\t" \
+        "palignr	$2, %%xmm6, %%xmm2      \n\t" \
         "pavgb      %%xmm2, %%xmm0          \n\t" \
         "movdqa     %%xmm6, %%xmm1          \n\t" \
         "movdqa     %%xmm7, %%xmm3          \n\t" \
-        "palignr	$15, %%xmm1, %%xmm5     \n\t" \
-        "palignr	$1, %%xmm3, %%xmm6      \n\t" \
+        "palignr	$15, %%xmm5, %%xmm1     \n\t" \
+        "palignr	$1, %%xmm6, %%xmm3      \n\t" \
         "pavgb      %%xmm6, %%xmm0          \n\t" \
         "pavgb      %%xmm3, %%xmm1          \n\t" \
         "pavgb      %%xmm6, %%xmm0          \n\t" \


### PR DESCRIPTION
Generally, blur assembler plugin works.
SIMD functions (g_cpuid & CPUF_SSE2) aren't working.
I deleted the emms functions.
Improved `y + x & ~x` functions.
